### PR TITLE
ci: skip playwright image in compose build

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -49,7 +49,7 @@ jobs:
           TELEGRAM_USER_ID=${{ secrets.TELEGRAM_USER_ID }}
           ENABLE_TELEGRAM=false
           EOF
-      - run: docker compose build
+      - run: docker compose build backend frontend adminer
       - run: docker compose down -v --remove-orphans
       - name: Try starting backend
         run: |


### PR DESCRIPTION
Why: playwright image OOMs/disk-fills GH runners during pnpm exec playwright install --with-deps, breaking CI on every PR even when the change is unrelated to the frontend. The test-docker-compose job only starts backend/frontend/adminer, so building the playwright image here is wasted work.