### PR TITLE
ci: unblock dependabot PRs (skip playwright build, dummy env vars)

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -74,8 +74,10 @@ jobs:
       env:
         VIRTUAL_ENV: backend/.venv
         SECRET_KEY: just-for-generating-client
+        POSTGRES_USER: just-for-generating-client
         POSTGRES_PASSWORD: just-for-generating-client
         FIRST_SUPERUSER_PASSWORD: just-for-generating-client
+        TMDB_KEY: just-for-generating-client
     - name: Add changes to git
       run: |
         git config --local user.email "github-actions@github.com"

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -49,7 +49,7 @@ jobs:
           TELEGRAM_USER_ID=${{ secrets.TELEGRAM_USER_ID }}
           ENABLE_TELEGRAM=false
           EOF
-      - run: docker compose build
+      - run: docker compose build backend frontend adminer
       - run: docker compose down -v --remove-orphans
       - name: Try starting backend
         run: |


### PR DESCRIPTION
## Summary
- Skip the playwright image in `test-docker-compose` — `pnpm exec playwright install --with-deps` was OOM/disk-filling the GH runner and crashing dockerd, breaking CI on every open PR even when unrelated to the frontend. The job only starts backend/frontend/adminer, so building playwright there was wasted work anyway.
- Add dummy `POSTGRES_USER` and `TMDB_KEY` to the `generate-client` job's env block — GitHub does not expose repo secrets to Dependabot-triggered workflows, so those fields ended up empty and pydantic-settings rejected them as missing. Matches the existing pattern for `SECRET_KEY` / `POSTGRES_PASSWORD`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: `@dependabot rebase` on open dependabot PRs and confirm their CI goes green