### PR TITLE
fix(alembic): migrate cinema.seating to new enum values

### DIFF
--- a/backend/app/alembic/versions/a1b2c3d4e5f6_rename_cinema_seating_values.py
+++ b/backend/app/alembic/versions/a1b2c3d4e5f6_rename_cinema_seating_values.py
@@ -1,0 +1,35 @@
+"""rename cinema seating values to new short form
+
+Revision ID: a1b2c3d4e5f6
+Revises: f0b7c3d5e9a1
+Create Date: 2026-05-30 14:00:00.000000
+"""
+
+from alembic import op
+
+revision = "a1b2c3d4e5f6"
+down_revision = "f0b7c3d5e9a1"
+branch_labels = None
+depends_on = None
+
+
+_OLD_TO_NEW = {
+    "row-number-seat-number": "number-number",
+    "row-letter-seat-number": "letter-number",
+    "row-number-seat-letter": "number-letter",
+    "row-letter-seat-letter": "letter-letter",
+}
+
+
+def upgrade() -> None:
+    for old, new in _OLD_TO_NEW.items():
+        op.execute(
+            f"UPDATE cinema SET seating = '{new}' WHERE seating = '{old}'"
+        )
+
+
+def downgrade() -> None:
+    for old, new in _OLD_TO_NEW.items():
+        op.execute(
+            f"UPDATE cinema SET seating = '{old}' WHERE seating = '{new}'"
+        )


### PR DESCRIPTION
## Summary
The cleanup PR (#245) renamed `CinemaSeatingPreset` values:
- `row-number-seat-number` → `number-number`
- `row-letter-seat-number` → `letter-number`
- `row-number-seat-letter` → `number-letter`
- `row-letter-seat-letter` → `letter-letter`

…but the staging/production DB still holds the old strings. The first SELECT against the `cinema` table tries to coerce them into the new enum and raises, which is what crashed prestart on the staging deploy of #245 (`service "prestart" didn't complete successfully: exit 1`).

Adds a one-shot Alembic migration that rewrites the four old values to their new form in place. `unknown` / `free` are unchanged. The migration is reversible and idempotent.

## Test plan
- [ ] CI green
- [ ] After merge, staging deploy succeeds (prestart completes)