### PR TITLE
ci(deploy-staging): surface prestart logs on failure

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,3 +53,6 @@ jobs:
           EOF
       - run: docker compose -f docker-compose.yml --project-name mikiboxd-staging build
       - run: docker compose -f docker-compose.yml --project-name mikiboxd-staging up --detach
+      - name: Dump prestart logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml --project-name mikiboxd-staging logs prestart backend --no-color --tail 200


### PR DESCRIPTION
The deploy of #248 still failed but the CI orchestrator output only shows 'service prestart didn't complete successfully: exit 1' — no idea what actually broke. Add a failure-only step that runs `docker compose logs prestart backend` so the next failed staging deploy surfaces the real error and we can fix it.

No runtime change.