### PR TITLE
fix(models/cinema): map seating enum by value (not name)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,3 +53,6 @@ jobs:
           EOF
       - run: docker compose -f docker-compose.yml --project-name mikiboxd-staging build
       - run: docker compose -f docker-compose.yml --project-name mikiboxd-staging up --detach
+      - name: Dump prestart logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml --project-name mikiboxd-staging logs prestart backend --no-color --tail 200

--- a/backend/app/models/cinema.py
+++ b/backend/app/models/cinema.py
@@ -2,7 +2,8 @@
 
 from typing import TYPE_CHECKING
 
-from sqlmodel import Field, Relationship, SQLModel
+from sqlalchemy import Enum as SAEnum
+from sqlmodel import Column, Field, Relationship, SQLModel
 
 from app.validators.cinema_seating import CinemaSeatingPreset
 
@@ -15,9 +16,22 @@ class CinemaBase(SQLModel):
     cineville: bool
     badge_bg_color: str
     url: str
-    # Pydantic coerces plain strings (e.g. "letter-number") to the enum automatically,
-    # so no manual validator is needed. Preset values are defined in CinemaSeatingPreset.
-    seating: CinemaSeatingPreset = Field(default=CinemaSeatingPreset.UNKNOWN)
+    # Store the lowercase enum *value* ("free", "number-number", ...) rather than
+    # the Python *name* ("FREE", "NUMBER_NUMBER", ...). SQLAlchemy's default Enum
+    # mapping uses the name; values_callable overrides that to use the value, which
+    # keeps the column human-readable and matches what cinemas.yaml writes.
+    seating: CinemaSeatingPreset = Field(
+        sa_column=Column(
+            SAEnum(
+                CinemaSeatingPreset,
+                native_enum=False,
+                length=40,
+                values_callable=lambda enum: [m.value for m in enum],
+            ),
+            nullable=False,
+        ),
+        default=CinemaSeatingPreset.UNKNOWN,
+    )
 
 
 class CinemaCreate(CinemaBase):


### PR DESCRIPTION
## Root cause
Real error finally surfaced by the new logging step:
```
LookupError: 'free' is not among the defined enum values.
Enum name: cinemaseatingpreset.
Possible values: UNKNOWN, FREE, NUMBER_NUMB.., ..., LETTER_LETT..
```

SQLAlchemy's `Enum` column maps by Python enum *name* (`UNKNOWN`, `FREE`, `NUMBER_NUMBER`, …) by default, but the DB column has always stored the lowercase *values* (`free`, `unknown`, `number-number`, …). After the cleanup PR re-typed `Cinema.seating` from `str` to `CinemaSeatingPreset`, every Cinema row read raised — which crashed staging prestart at the seed step.

## Fix
Use `values_callable` + `native_enum=False` so SQLAlchemy stores/reads the enum *values* instead of names. Matches what `cinemas.yaml` writes and what every existing DB row already contains.

The previously-merged migration (`a1b2c3d4e5f6`) is still needed for the four renamed values (`row-letter-seat-number` → `letter-number`, etc.). It already ran on staging at the prior deploy, so the renamed strings are now in the new form — this PR just makes the model read them correctly.

## Test plan
- [ ] CI green
- [ ] Staging deploy completes (prestart succeeds, app comes up)