### PR TITLE
feat(api): add count endpoints for showtimes and movies

### DIFF
--- a/backend/app/api/routes/movies.py
+++ b/backend/app/api/routes/movies.py
@@ -11,6 +11,19 @@ from app.services import movies as movies_service
 router = APIRouter(prefix="/movies", tags=["movies"])
 
 
+@router.get("/count")
+def count_movies(
+    session: SessionDep,
+    current_user: CurrentUser,
+    filters: Filters = Depends(get_filters),
+) -> int:
+    return movies_service.count_movie_summaries(
+        session=session,
+        user_id=current_user.id,
+        filters=filters,
+    )
+
+
 @router.get("/", response_model=list[MovieSummaryLoggedIn])
 def read_movies(
     session: SessionDep,

--- a/backend/app/api/routes/showtimes.py
+++ b/backend/app/api/routes/showtimes.py
@@ -165,6 +165,20 @@ def update_showtime_visibility(
         )
 
 
+@router.get("/count")
+def count_main_page_showtimes(
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    filters: Filters = Depends(get_filters),
+) -> int:
+    return showtimes_service.count_main_page_showtimes(
+        session=session,
+        current_user_id=current_user.id,
+        filters=filters,
+    )
+
+
 @router.get("/")
 def get_main_page_showtimes(
     *,

--- a/backend/app/crud/movie.py
+++ b/backend/app/crud/movie.py
@@ -597,3 +597,85 @@ def get_movies(
     result = session.execute(stmt)
     movies: list[Movie] = list(result.scalars().all())
     return movies
+
+
+def count_movies(
+    *,
+    session: Session,
+    current_user_id: UUID,
+    letterboxd_username: str | None,
+    filters: Filters,
+) -> int:
+    stmt = (
+        select(Movie)
+        .join(Showtime, col(Movie.id) == Showtime.movie_id)
+        .where(
+            col(Showtime.datetime) >= filters.snapshot_time,
+        )
+    )
+    if filters.selected_cinema_ids is not None and len(filters.selected_cinema_ids) > 0:
+        stmt = stmt.where(col(Showtime.cinema_id).in_(filters.selected_cinema_ids))
+
+    if filters.query:
+        pattern = f"%{filters.query}%"
+        stmt = stmt.where(
+            col(Movie.title).ilike(pattern) | col(Movie.original_title).ilike(pattern)
+        )
+
+    if filters.runtime_min is not None:
+        stmt = stmt.where(col(Movie.duration) >= filters.runtime_min)
+
+    if filters.runtime_max is not None:
+        stmt = stmt.where(col(Movie.duration) <= filters.runtime_max)
+
+    if filters.watchlist_only:
+        stmt = stmt.join(
+            WatchlistSelection, col(WatchlistSelection.movie_id) == Movie.id
+        ).where(col(WatchlistSelection.letterboxd_username) == letterboxd_username)
+
+    if filters.days is not None and len(filters.days) > 0:
+        stmt = stmt.where(
+            day_bucket_date_clause(col(Showtime.datetime)).in_(filters.days)
+        )
+
+    if filters.time_ranges is not None and len(filters.time_ranges) > 0:
+        stmt = stmt.where(
+            or_(
+                *[
+                    time_range_clause(
+                        col(Showtime.datetime),
+                        col(Showtime.end_datetime),
+                        tr.start,
+                        tr.end,
+                    )
+                    for tr in filters.time_ranges
+                ]
+            )
+        )
+
+    if filters.selected_statuses is not None and len(filters.selected_statuses) > 0:
+        visible_row = aliased(ShowtimeVisibilityEffective)
+        stmt = (
+            stmt.join(
+                ShowtimeSelection,
+                col(Showtime.id) == col(ShowtimeSelection.showtime_id),
+            )
+            .outerjoin(
+                visible_row,
+                (col(visible_row.owner_id) == col(ShowtimeSelection.user_id))
+                & (col(visible_row.showtime_id) == col(Showtime.id))
+                & (col(visible_row.viewer_id) == current_user_id),
+            )
+            .where(
+                or_(
+                    col(ShowtimeSelection.user_id) == current_user_id,
+                    col(visible_row.viewer_id).is_not(None),
+                ),
+                col(ShowtimeSelection.going_status).in_(filters.selected_statuses),
+            )
+        )
+
+    count_stmt = select(func.count()).select_from(
+        stmt.group_by(col(Movie.id)).subquery()
+    )
+    return session.execute(count_stmt).scalar_one()

--- a/backend/app/crud/showtime.py
+++ b/backend/app/crud/showtime.py
@@ -393,6 +393,93 @@ def get_main_page_showtimes(
     return showtimes
 
 
+def count_main_page_showtimes(
+    *,
+    session: Session,
+    user_id: UUID,
+    filters: Filters,
+    letterboxd_username: str | None = None,
+) -> int:
+    stmt = select(Showtime).where(Showtime.datetime >= filters.snapshot_time)
+
+    if filters.selected_cinema_ids is not None and len(filters.selected_cinema_ids) > 0:
+        stmt = stmt.where(col(Showtime.cinema_id).in_(filters.selected_cinema_ids))
+
+    if filters.days is not None and len(filters.days) > 0:
+        stmt = stmt.where(
+            day_bucket_date_clause(col(Showtime.datetime)).in_(filters.days)
+        )
+
+    if filters.time_ranges is not None and len(filters.time_ranges) > 0:
+        stmt = stmt.where(
+            or_(
+                *[
+                    time_range_clause(
+                        col(Showtime.datetime),
+                        col(Showtime.end_datetime),
+                        tr.start,
+                        tr.end,
+                    )
+                    for tr in filters.time_ranges
+                ]
+            )
+        )
+
+    if (
+        filters.query
+        or filters.watchlist_only
+        or filters.runtime_min is not None
+        or filters.runtime_max is not None
+    ):
+        stmt = stmt.join(Movie, col(Movie.id) == col(Showtime.movie_id))
+
+    if filters.query:
+        pattern = f"%{filters.query}%"
+        stmt = stmt.where(
+            col(Movie.title).ilike(pattern) | col(Movie.original_title).ilike(pattern)
+        )
+
+    if filters.runtime_min is not None:
+        stmt = stmt.where(col(Movie.duration) >= filters.runtime_min)
+
+    if filters.runtime_max is not None:
+        stmt = stmt.where(col(Movie.duration) <= filters.runtime_max)
+
+    if filters.watchlist_only:
+        if letterboxd_username is None:
+            return 0
+        stmt = stmt.join(
+            WatchlistSelection,
+            col(WatchlistSelection.movie_id) == col(Showtime.movie_id),
+        ).where(col(WatchlistSelection.letterboxd_username) == letterboxd_username)
+
+    if filters.selected_statuses is not None and len(filters.selected_statuses) > 0:
+        visible_row = aliased(ShowtimeVisibilityEffective)
+        stmt = (
+            stmt.join(
+                ShowtimeSelection,
+                col(Showtime.id) == col(ShowtimeSelection.showtime_id),
+            )
+            .outerjoin(
+                visible_row,
+                (col(visible_row.owner_id) == col(ShowtimeSelection.user_id))
+                & (col(visible_row.showtime_id) == col(Showtime.id))
+                & (col(visible_row.viewer_id) == user_id),
+            )
+            .where(
+                or_(
+                    col(ShowtimeSelection.user_id) == user_id,
+                    col(visible_row.viewer_id).is_not(None),
+                ),
+                col(ShowtimeSelection.going_status).in_(filters.selected_statuses),
+            )
+            .distinct()
+        )
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    return session.execute(count_stmt).scalar_one()
+
+
 def add_showtime_selection(
     *,
     session: Session,

--- a/backend/app/services/movies.py
+++ b/backend/app/services/movies.py
@@ -65,6 +65,37 @@ def get_movie_summaries(
     return movies
 
 
+def count_movie_summaries(
+    *,
+    session: Session,
+    user_id: UUID,
+    filters: Filters,
+) -> int:
+    letterboxd_username = users_crud.get_letterboxd_username(
+        session=session,
+        user_id=user_id,
+    )
+    if filters.selected_cinema_ids is None:
+        favorite_preset = cinema_presets_crud.get_user_favorite_preset(
+            session=session,
+            user_id=user_id,
+        )
+        if favorite_preset is not None:
+            filters.selected_cinema_ids = list(favorite_preset.cinema_ids)
+        else:
+            filters.selected_cinema_ids = users_crud.get_selected_cinemas_ids(
+                session=session,
+                user_id=user_id,
+            )
+
+    return movies_crud.count_movies(
+        session=session,
+        current_user_id=user_id,
+        letterboxd_username=letterboxd_username,
+        filters=filters,
+    )
+
+
 def get_movie_by_id(
     *,
     session: Session,

--- a/backend/app/services/showtimes.py
+++ b/backend/app/services/showtimes.py
@@ -967,3 +967,36 @@ def get_main_page_showtimes(
         )
         for showtime in showtimes
     ]
+
+
+def count_main_page_showtimes(
+    *,
+    session: Session,
+    current_user_id: UUID,
+    filters: Filters,
+) -> int:
+    if filters.selected_cinema_ids is None:
+        favorite_preset = cinema_presets_crud.get_user_favorite_preset(
+            session=session,
+            user_id=current_user_id,
+        )
+        if favorite_preset is not None:
+            filters.selected_cinema_ids = list(favorite_preset.cinema_ids)
+        else:
+            filters.selected_cinema_ids = user_crud.get_selected_cinemas_ids(
+                session=session,
+                user_id=current_user_id,
+            )
+
+    letterboxd_username = None
+    if filters.watchlist_only:
+        letterboxd_username = user_crud.get_letterboxd_username(
+            session=session,
+            user_id=current_user_id,
+        )
+    return showtimes_crud.count_main_page_showtimes(
+        session=session,
+        user_id=current_user_id,
+        filters=filters,
+        letterboxd_username=letterboxd_username,
+    )

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -76,6 +76,8 @@ import type {
   MeRegisterPushTokenResponse,
   MeDeletePushTokenData,
   MeDeletePushTokenResponse,
+  MoviesCountMoviesData,
+  MoviesCountMoviesResponse,
   MoviesReadMoviesData,
   MoviesReadMoviesResponse,
   MoviesReadMovieShowtimesData,
@@ -98,6 +100,8 @@ import type {
   ShowtimesGetShowtimeVisibilityResponse,
   ShowtimesUpdateShowtimeVisibilityData,
   ShowtimesUpdateShowtimeVisibilityResponse,
+  ShowtimesCountMainPageShowtimesData,
+  ShowtimesCountMainPageShowtimesResponse,
   ShowtimesGetMainPageShowtimesData,
   ShowtimesGetMainPageShowtimesResponse,
   UsersSearchUsersData,
@@ -959,6 +963,46 @@ export class MeService {
 
 export class MoviesService {
   /**
+   * Count Movies
+   * @param data The data for the request.
+   * @param data.query
+   * @param data.snapshotTime Only show showtimes after this moment
+   * @param data.watchlistOnly
+   * @param data.selectedCinemaIds Filter showtimes to only these cinema IDs
+   * @param data.days
+   * @param data.timeRanges
+   * @param data.timesOfDay Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   * @param data.selectedStatuses Filter by selection statuses (GOING/INTERESTED)
+   * @param data.runtimeMin Minimum movie runtime in minutes
+   * @param data.runtimeMax Maximum movie runtime in minutes
+   * @returns number Successful Response
+   * @throws ApiError
+   */
+  public static countMovies(
+    data: MoviesCountMoviesData = {},
+  ): CancelablePromise<MoviesCountMoviesResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/movies/count",
+      query: {
+        query: data.query,
+        snapshot_time: data.snapshotTime,
+        watchlist_only: data.watchlistOnly,
+        selected_cinema_ids: data.selectedCinemaIds,
+        days: data.days,
+        time_ranges: data.timeRanges,
+        times_of_day: data.timesOfDay,
+        selected_statuses: data.selectedStatuses,
+        runtime_min: data.runtimeMin,
+        runtime_max: data.runtimeMax,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
    * Read Movies
    * @param data The data for the request.
    * @param data.offset
@@ -1282,6 +1326,46 @@ export class ShowtimesService {
       },
       body: data.requestBody,
       mediaType: "application/json",
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Count Main Page Showtimes
+   * @param data The data for the request.
+   * @param data.query
+   * @param data.snapshotTime Only show showtimes after this moment
+   * @param data.watchlistOnly
+   * @param data.selectedCinemaIds Filter showtimes to only these cinema IDs
+   * @param data.days
+   * @param data.timeRanges
+   * @param data.timesOfDay Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   * @param data.selectedStatuses Filter by selection statuses (GOING/INTERESTED)
+   * @param data.runtimeMin Minimum movie runtime in minutes
+   * @param data.runtimeMax Maximum movie runtime in minutes
+   * @returns number Successful Response
+   * @throws ApiError
+   */
+  public static countMainPageShowtimes(
+    data: ShowtimesCountMainPageShowtimesData = {},
+  ): CancelablePromise<ShowtimesCountMainPageShowtimesResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/showtimes/count",
+      query: {
+        query: data.query,
+        snapshot_time: data.snapshotTime,
+        watchlist_only: data.watchlistOnly,
+        selected_cinema_ids: data.selectedCinemaIds,
+        days: data.days,
+        time_ranges: data.timeRanges,
+        times_of_day: data.timesOfDay,
+        selected_statuses: data.selectedStatuses,
+        runtime_min: data.runtimeMin,
+        runtime_max: data.runtimeMax,
+      },
       errors: {
         422: "Validation Error",
       },

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -607,6 +607,39 @@ export type MeDeletePushTokenData = {
 
 export type MeDeletePushTokenResponse = Message
 
+export type MoviesCountMoviesData = {
+  days?: Array<string> | null
+  query?: string | null
+  /**
+   * Maximum movie runtime in minutes
+   */
+  runtimeMax?: number | null
+  /**
+   * Minimum movie runtime in minutes
+   */
+  runtimeMin?: number | null
+  /**
+   * Filter showtimes to only these cinema IDs
+   */
+  selectedCinemaIds?: Array<number> | null
+  /**
+   * Filter by selection statuses (GOING/INTERESTED)
+   */
+  selectedStatuses?: Array<GoingStatus> | null
+  /**
+   * Only show showtimes after this moment
+   */
+  snapshotTime?: string | null
+  timeRanges?: Array<string> | null
+  /**
+   * Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   */
+  timesOfDay?: Array<TimeOfDay> | null
+  watchlistOnly?: boolean
+}
+
+export type MoviesCountMoviesResponse = number
+
 export type MoviesReadMoviesData = {
   days?: Array<string> | null
   limit?: number
@@ -767,6 +800,39 @@ export type ShowtimesUpdateShowtimeVisibilityData = {
 }
 
 export type ShowtimesUpdateShowtimeVisibilityResponse = ShowtimeVisibilityPublic
+
+export type ShowtimesCountMainPageShowtimesData = {
+  days?: Array<string> | null
+  query?: string | null
+  /**
+   * Maximum movie runtime in minutes
+   */
+  runtimeMax?: number | null
+  /**
+   * Minimum movie runtime in minutes
+   */
+  runtimeMin?: number | null
+  /**
+   * Filter showtimes to only these cinema IDs
+   */
+  selectedCinemaIds?: Array<number> | null
+  /**
+   * Filter by selection statuses (GOING/INTERESTED)
+   */
+  selectedStatuses?: Array<GoingStatus> | null
+  /**
+   * Only show showtimes after this moment
+   */
+  snapshotTime?: string | null
+  timeRanges?: Array<string> | null
+  /**
+   * Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   */
+  timesOfDay?: Array<TimeOfDay> | null
+  watchlistOnly?: boolean
+}
+
+export type ShowtimesCountMainPageShowtimesResponse = number
 
 export type ShowtimesGetMainPageShowtimesData = {
   days?: Array<string> | null


### PR DESCRIPTION
## Summary
- Adds `GET /showtimes/count` — returns total filtered showtime count for the main page query
- Adds `GET /movies/count` — returns total filtered movie count
- Both endpoints accept the same `Filters` dependency as their paginated counterparts and apply identical cinema/day/time/runtime/watchlist/status filter logic
- Regenerated shared OpenAPI client with the two new service methods (`ShowtimesService.countMainPageShowtimes`, `MoviesService.countMovies`)

## Motivation
Enables the filter modal UI to display a "Show N Showtimes / Show N Movies" button that reflects the exact total count under the current filters, rather than only counting loaded pages.

## Test plan
- [ ] `GET /showtimes/count` with no filters returns the same count as the total items across all pages of `GET /showtimes/`
- [ ] `GET /movies/count` with no filters matches total pages of `GET /movies/`
- [ ] Filters (cinemas, days, time, runtime, watchlist, status) reduce the count as expected
- [ ] No merge conflicts expected with `ui-overhaul` branch (backend is untouched there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)