### PR TITLE
fix(api): add GET /me/showtimes/count for user-specific showtime count

### DIFF
--- a/backend/app/api/routes/me.py
+++ b/backend/app/api/routes/me.py
@@ -365,6 +365,19 @@ def update_password_me(
     return Message(message="Password updated successfully")
 
 
+@router.get("/showtimes/count")
+def count_my_showtimes(
+    session: SessionDep,
+    current_user: CurrentUser,
+    filters: Filters = Depends(get_filters),
+) -> int:
+    return users_service.count_selected_showtimes(
+        session=session,
+        current_user_id=current_user.id,
+        filters=filters,
+    )
+
+
 @router.get("/showtimes", response_model=list[ShowtimeLoggedIn])
 def get_my_showtimes(
     session: SessionDep,

--- a/backend/app/crud/user.py
+++ b/backend/app/crud/user.py
@@ -425,6 +425,94 @@ def get_selected_showtimes(
     return showtimes
 
 
+def count_selected_showtimes(
+    *,
+    session: Session,
+    user_id: UUID,
+    viewer_id: UUID | None,
+    filters: Filters,
+    letterboxd_username: str | None = None,
+) -> int:
+    stmt = (
+        select(Showtime)
+        .join(
+            ShowtimeSelection,
+            col(Showtime.id) == ShowtimeSelection.showtime_id,
+        )
+        .where(
+            ShowtimeSelection.user_id == user_id,
+            Showtime.datetime >= filters.snapshot_time,
+        )
+    )
+
+    if viewer_id is not None and viewer_id != user_id:
+        stmt = stmt.join(
+            ShowtimeVisibilityEffective,
+            (col(ShowtimeVisibilityEffective.owner_id) == user_id)
+            & (col(ShowtimeVisibilityEffective.showtime_id) == col(Showtime.id))
+            & (col(ShowtimeVisibilityEffective.viewer_id) == viewer_id),
+        )
+
+    if filters.selected_statuses is not None and len(filters.selected_statuses) > 0:
+        stmt = stmt.where(
+            col(ShowtimeSelection.going_status).in_(filters.selected_statuses)
+        )
+
+    if filters.selected_cinema_ids is not None and len(filters.selected_cinema_ids) > 0:
+        stmt = stmt.where(col(Showtime.cinema_id).in_(filters.selected_cinema_ids))
+
+    if filters.days is not None and len(filters.days) > 0:
+        stmt = stmt.where(
+            day_bucket_date_clause(col(Showtime.datetime)).in_(filters.days)
+        )
+
+    if filters.time_ranges is not None and len(filters.time_ranges) > 0:
+        stmt = stmt.where(
+            or_(
+                *[
+                    time_range_clause(
+                        col(Showtime.datetime),
+                        col(Showtime.end_datetime),
+                        tr.start,
+                        tr.end,
+                    )
+                    for tr in filters.time_ranges
+                ]
+            )
+        )
+
+    if (
+        filters.query
+        or filters.watchlist_only
+        or filters.runtime_min is not None
+        or filters.runtime_max is not None
+    ):
+        stmt = stmt.join(Movie, col(Movie.id) == col(Showtime.movie_id))
+
+    if filters.query:
+        pattern = f"%{filters.query}%"
+        stmt = stmt.where(
+            col(Movie.title).ilike(pattern) | col(Movie.original_title).ilike(pattern)
+        )
+
+    if filters.runtime_min is not None:
+        stmt = stmt.where(col(Movie.duration) >= filters.runtime_min)
+
+    if filters.runtime_max is not None:
+        stmt = stmt.where(col(Movie.duration) <= filters.runtime_max)
+
+    if filters.watchlist_only:
+        if letterboxd_username is None:
+            return 0
+        stmt = stmt.join(
+            WatchlistSelection,
+            col(WatchlistSelection.movie_id) == col(Showtime.movie_id),
+        ).where(col(WatchlistSelection.letterboxd_username) == letterboxd_username)
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    return session.execute(count_stmt).scalar_one()
+
+
 def get_sent_friend_requests(*, session: Session, user_id: UUID) -> list[User]:
     """
     Get a list of users to whom the specified user has sent friend requests.

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -133,6 +133,27 @@ def get_selected_showtimes(
     ]
 
 
+def count_selected_showtimes(
+    *,
+    session: Session,
+    current_user_id: UUID,
+    filters: Filters,
+) -> int:
+    letterboxd_username = None
+    if filters.watchlist_only:
+        letterboxd_username = users_crud.get_letterboxd_username(
+            session=session,
+            user_id=current_user_id,
+        )
+    return users_crud.count_selected_showtimes(
+        session=session,
+        user_id=current_user_id,
+        viewer_id=current_user_id,
+        filters=filters,
+        letterboxd_username=letterboxd_username,
+    )
+
+
 def get_friends(
     *,
     session: Session,

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -57,6 +57,8 @@ import type {
   MeDeleteFriendGroupResponse,
   MeUpdatePasswordMeData,
   MeUpdatePasswordMeResponse,
+  MeCountMyShowtimesData,
+  MeCountMyShowtimesResponse,
   MeGetMyShowtimesData,
   MeGetMyShowtimesResponse,
   MeGetMyShowtimePingsData,
@@ -715,6 +717,46 @@ export class MeService {
       url: "/api/v1/me/password",
       body: data.requestBody,
       mediaType: "application/json",
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Count My Showtimes
+   * @param data The data for the request.
+   * @param data.query
+   * @param data.snapshotTime Only show showtimes after this moment
+   * @param data.watchlistOnly
+   * @param data.selectedCinemaIds Filter showtimes to only these cinema IDs
+   * @param data.days
+   * @param data.timeRanges
+   * @param data.timesOfDay Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   * @param data.selectedStatuses Filter by selection statuses (GOING/INTERESTED)
+   * @param data.runtimeMin Minimum movie runtime in minutes
+   * @param data.runtimeMax Maximum movie runtime in minutes
+   * @returns number Successful Response
+   * @throws ApiError
+   */
+  public static countMyShowtimes(
+    data: MeCountMyShowtimesData = {},
+  ): CancelablePromise<MeCountMyShowtimesResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/me/showtimes/count",
+      query: {
+        query: data.query,
+        snapshot_time: data.snapshotTime,
+        watchlist_only: data.watchlistOnly,
+        selected_cinema_ids: data.selectedCinemaIds,
+        days: data.days,
+        time_ranges: data.timeRanges,
+        times_of_day: data.timesOfDay,
+        selected_statuses: data.selectedStatuses,
+        runtime_min: data.runtimeMin,
+        runtime_max: data.runtimeMax,
+      },
       errors: {
         422: "Validation Error",
       },

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -526,6 +526,39 @@ export type MeUpdatePasswordMeData = {
 
 export type MeUpdatePasswordMeResponse = Message
 
+export type MeCountMyShowtimesData = {
+  days?: Array<string> | null
+  query?: string | null
+  /**
+   * Maximum movie runtime in minutes
+   */
+  runtimeMax?: number | null
+  /**
+   * Minimum movie runtime in minutes
+   */
+  runtimeMin?: number | null
+  /**
+   * Filter showtimes to only these cinema IDs
+   */
+  selectedCinemaIds?: Array<number> | null
+  /**
+   * Filter by selection statuses (GOING/INTERESTED)
+   */
+  selectedStatuses?: Array<GoingStatus> | null
+  /**
+   * Only show showtimes after this moment
+   */
+  snapshotTime?: string | null
+  timeRanges?: Array<string> | null
+  /**
+   * Preset time windows (MORNING/AFTERNOON/EVENING/NIGHT)
+   */
+  timesOfDay?: Array<TimeOfDay> | null
+  watchlistOnly?: boolean
+}
+
+export type MeCountMyShowtimesResponse = number
+
 export type MeGetMyShowtimesData = {
   days?: Array<string> | null
   limit?: number


### PR DESCRIPTION
## Summary
- Adds `GET /me/showtimes/count` — returns the total filtered count of the current user's selected showtimes
- Mirrors `GET /me/showtimes` exactly: same filter logic (`selected_statuses`, `selected_cinema_ids`, `days`, `time_ranges`, `runtime`, `watchlist_only`), same visibility rules
- Needed to support the "View N Showtimes" button in the filter modal when the audience toggle is set to "only-you" (which switches the list query from `/showtimes` to `/me/showtimes`)
- Regenerated shared client with `MeService.countMyShowtimes`

## Why this was missing
The original count PR (#251) added `/showtimes/count` and `/movies/count` but missed that the index screen uses a separate `/me/showtimes` endpoint when audience is set to "only-you".

## Test plan
- [ ] `GET /me/showtimes/count` returns same total as pages of `GET /me/showtimes` with identical filters
- [ ] Status, cinema, day, time, runtime, and watchlist filters all reduce the count correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)