### PR TITLE
feat(showtimes): add GET /showtimes/{showtime_id} endpoint

### DIFF
--- a/backend/app/api/routes/showtimes.py
+++ b/backend/app/api/routes/showtimes.py
@@ -195,3 +195,21 @@ def get_main_page_showtimes(
         offset=offset,
         filters=filters,
     )
+
+
+# Declared last so the literal routes above (/count, /visibility/batch, /) are
+# matched first and never shadowed by this dynamic single-segment route.
+@router.get("/{showtime_id}", response_model=ShowtimeLoggedIn)
+def get_showtime_by_id(
+    *,
+    session: SessionDep,
+    showtime_id: int,
+    current_user: CurrentUser,
+) -> ShowtimeLoggedIn:
+    # ShowtimeNotFoundError (an AppError, 404) is converted to JSON by the
+    # global app exception handler, so no explicit try/except is needed here.
+    return showtimes_service.get_showtime_by_id(
+        session=session,
+        showtime_id=showtime_id,
+        current_user=current_user.id,
+    )

--- a/backend/tests/api/test_showtimes.py
+++ b/backend/tests/api/test_showtimes.py
@@ -1240,6 +1240,66 @@ def test_update_showtime_selection_rejects_seat_only_seat_value(
     assert "both be set or both be empty" in seat_only_response.json()["detail"]
 
 
+def test_get_showtime_by_id_returns_showtime(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+    showtime_factory,
+) -> None:
+    showtime = showtime_factory()
+    showtime_id = showtime.id
+    movie_id = showtime.movie_id
+
+    response = client.get(
+        f"{settings.API_V1_STR}/showtimes/{showtime_id}",
+        headers=normal_user_token_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == showtime_id
+    assert body["movie"]["id"] == movie_id
+    assert "cinema" in body
+    assert body["going"] == "NOT_GOING"
+    assert body["friends_going"] == []
+    assert body["friends_interested"] == []
+
+
+def test_get_showtime_by_id_reflects_current_user_status(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+    showtime_factory,
+) -> None:
+    showtime = showtime_factory()
+    showtime_id = showtime.id
+
+    selection_response = client.put(
+        f"{settings.API_V1_STR}/showtimes/selection/{showtime_id}",
+        headers=normal_user_token_headers,
+        json={"going_status": "INTERESTED"},
+    )
+    assert selection_response.status_code == 200
+
+    response = client.get(
+        f"{settings.API_V1_STR}/showtimes/{showtime_id}",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["going"] == "INTERESTED"
+
+
+def test_get_showtime_by_id_returns_404_for_unknown_id(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+) -> None:
+    response = client.get(
+        f"{settings.API_V1_STR}/showtimes/99999999",
+        headers=normal_user_token_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Showtime with ID 99999999 not found."
+
+
 def test_main_page_showtimes_includes_friend_seat_in_badge_payload(
     client: TestClient,
     normal_user_token_headers: dict[str, str],

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -104,6 +104,8 @@ import type {
   ShowtimesCountMainPageShowtimesResponse,
   ShowtimesGetMainPageShowtimesData,
   ShowtimesGetMainPageShowtimesResponse,
+  ShowtimesGetShowtimeByIdData,
+  ShowtimesGetShowtimeByIdResponse,
   UsersSearchUsersData,
   UsersSearchUsersResponse,
   UsersRegisterUserData,
@@ -1409,6 +1411,28 @@ export class ShowtimesService {
         selected_statuses: data.selectedStatuses,
         runtime_min: data.runtimeMin,
         runtime_max: data.runtimeMax,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Get Showtime By Id
+   * @param data The data for the request.
+   * @param data.showtimeId
+   * @returns ShowtimeLoggedIn Successful Response
+   * @throws ApiError
+   */
+  public static getShowtimeById(
+    data: ShowtimesGetShowtimeByIdData,
+  ): CancelablePromise<ShowtimesGetShowtimeByIdResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/showtimes/{showtime_id}",
+      path: {
+        showtime_id: data.showtimeId,
       },
       errors: {
         422: "Validation Error",

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -869,6 +869,12 @@ export type ShowtimesGetMainPageShowtimesData = {
 
 export type ShowtimesGetMainPageShowtimesResponse = Array<ShowtimeLoggedIn>
 
+export type ShowtimesGetShowtimeByIdData = {
+  showtimeId: number
+}
+
+export type ShowtimesGetShowtimeByIdResponse = ShowtimeLoggedIn
+
 export type UsersSearchUsersData = {
   limit?: number
   offset?: number


### PR DESCRIPTION
Add a single-showtime-by-id endpoint returning ShowtimeLoggedIn for the current user, reusing the existing showtimes_service.get_showtime_by_id. The route is declared last so it never shadows the literal /count, /visibility/batch and / routes; ShowtimeNotFoundError is converted to a 404 by the global AppError handler. Regenerate the typed client (ShowtimesService.getShowtimeById) and add API tests (200, status reflection, 404).

This unblocks opening the showtime modal from just an id (deep links / notifications / future notification centre) on the mobile app.