### PR TITLE
feat(agenda): GET /me/agenda + embed invite info in showtimes

### DIFF
--- a/backend/app/api/routes/me.py
+++ b/backend/app/api/routes/me.py
@@ -4,6 +4,7 @@ All routes are scoped to the authenticated user — they operate on the user's
 own data (profile, presets, cinemas, pings, friends, watchlist, push tokens).
 """
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -29,6 +30,7 @@ from app.schemas.user import UserMe, UserWithFriendStatus
 from app.services import me as me_service
 from app.services import users as users_service
 from app.services import watchlist as watchlist_service
+from app.utils import now_amsterdam_naive
 
 router = APIRouter(prefix="/me", tags=["me"])
 
@@ -393,6 +395,31 @@ def get_my_showtimes(
         limit=limit,
         offset=offset,
         filters=filters,
+    )
+
+
+@router.get("/agenda", response_model=list[ShowtimeLoggedIn])
+def get_my_agenda(
+    session: SessionDep,
+    current_user: CurrentUser,
+    include_interested: bool = Query(True),
+    include_invited: bool = Query(True),
+    snapshot_time: datetime | None = Query(
+        None, description="Only show showtimes after this moment"
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> list[ShowtimeLoggedIn]:
+    if snapshot_time is None:
+        snapshot_time = now_amsterdam_naive()
+    return me_service.get_agenda_showtimes(
+        session=session,
+        user_id=current_user.id,
+        snapshot_time=snapshot_time,
+        include_interested=include_interested,
+        include_invited=include_invited,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/backend/app/converters/showtime.py
+++ b/backend/app/converters/showtime.py
@@ -7,6 +7,7 @@ from app.converters import movie as movie_converters
 from app.converters import user as user_converters
 from app.core.enums import GoingStatus
 from app.crud import showtime as showtime_crud
+from app.crud import showtime_ping as showtime_ping_crud
 from app.models.showtime import Showtime
 from app.models.showtime_selection import ShowtimeSelection
 from app.models.user import User
@@ -77,6 +78,30 @@ def _friends_for_showtime(
     return friends_going, friends_interested
 
 
+def _invite_info_for_showtime(
+    *,
+    session: Session,
+    showtime_id: int,
+    user_id: UUID,
+) -> tuple[list, list[int]]:
+    """Unique senders + ping ids of the user's active received pings for a showtime."""
+    pings = showtime_ping_crud.get_received_pings_for_showtime(
+        session=session,
+        showtime_id=showtime_id,
+        receiver_id=user_id,
+    )
+    invited_by = []
+    invite_ping_ids: list[int] = []
+    seen_sender_ids: set[UUID] = set()
+    for ping, sender in pings:
+        if ping.id is not None:
+            invite_ping_ids.append(ping.id)
+        if sender.id not in seen_sender_ids:
+            seen_sender_ids.add(sender.id)
+            invited_by.append(user_converters.to_public(sender))
+    return invited_by, invite_ping_ids
+
+
 def to_logged_in(
     showtime: Showtime,
     *,
@@ -111,6 +136,11 @@ def to_logged_in(
     going, seat_row, seat_number = _selection_status_and_seat(
         selection=current_selection
     )
+    invited_by, invite_ping_ids = _invite_info_for_showtime(
+        session=session,
+        showtime_id=showtime.id,
+        user_id=user_id,
+    )
     movie = movie_converters.to_in_showtime(showtime.movie)
     cinema = cinema_converters.to_public(
         cinema=showtime.cinema,
@@ -125,6 +155,8 @@ def to_logged_in(
         seat_number=seat_number,
         movie=movie,
         cinema=cinema,
+        invited_by=invited_by,
+        invite_ping_ids=invite_ping_ids,
     )
 
 
@@ -161,6 +193,11 @@ def to_in_movie_logged_in(
     going, seat_row, seat_number = _selection_status_and_seat(
         selection=current_selection
     )
+    invited_by, invite_ping_ids = _invite_info_for_showtime(
+        session=session,
+        showtime_id=showtime.id,
+        user_id=user_id,
+    )
     cinema = cinema_converters.to_public(
         cinema=showtime.cinema,
     )
@@ -173,4 +210,6 @@ def to_in_movie_logged_in(
         seat_row=seat_row,
         seat_number=seat_number,
         cinema=cinema,
+        invited_by=invited_by,
+        invite_ping_ids=invite_ping_ids,
     )

--- a/backend/app/crud/showtime.py
+++ b/backend/app/crud/showtime.py
@@ -13,6 +13,7 @@ from app.inputs.movie import Filters
 from app.models.friendship import Friendship
 from app.models.movie import Movie
 from app.models.showtime import Showtime, ShowtimeCreate
+from app.models.showtime_ping import ShowtimePing
 from app.models.showtime_selection import ShowtimeSelection
 from app.models.showtime_visibility import ShowtimeVisibilityEffective
 from app.models.user import User
@@ -391,6 +392,51 @@ def get_main_page_showtimes(
     stmt = stmt.order_by(col(Showtime.datetime)).limit(limit).offset(offset)
     showtimes = list(session.exec(stmt).all())
     return showtimes
+
+
+def get_agenda_showtimes(
+    *,
+    session: Session,
+    user_id: UUID,
+    snapshot_time: datetime,
+    include_interested: bool,
+    include_invited: bool,
+    limit: int,
+    offset: int,
+) -> list[Showtime]:
+    """
+    Upcoming showtimes for the user's personal agenda: ones they are GOING to
+    (always), INTERESTED in (when ``include_interested``), or have an active
+    received invite for (when ``include_invited``). Ordered by datetime.
+    """
+    going_subquery = select(ShowtimeSelection.showtime_id).where(
+        col(ShowtimeSelection.user_id) == user_id,
+        col(ShowtimeSelection.going_status) == GoingStatus.GOING,
+    )
+    conditions = [col(Showtime.id).in_(going_subquery)]
+
+    if include_interested:
+        interested_subquery = select(ShowtimeSelection.showtime_id).where(
+            col(ShowtimeSelection.user_id) == user_id,
+            col(ShowtimeSelection.going_status) == GoingStatus.INTERESTED,
+        )
+        conditions.append(col(Showtime.id).in_(interested_subquery))
+
+    if include_invited:
+        invited_subquery = select(ShowtimePing.showtime_id).where(
+            col(ShowtimePing.receiver_id) == user_id,
+            col(ShowtimePing.dismissed_at).is_(None),
+        )
+        conditions.append(col(Showtime.id).in_(invited_subquery))
+
+    stmt = (
+        select(Showtime)
+        .where(col(Showtime.datetime) >= snapshot_time, or_(*conditions))
+        .order_by(col(Showtime.datetime))
+        .limit(limit)
+        .offset(offset)
+    )
+    return list(session.exec(stmt).all())
 
 
 def count_main_page_showtimes(

--- a/backend/app/crud/showtime_ping.py
+++ b/backend/app/crud/showtime_ping.py
@@ -139,6 +139,26 @@ def get_received_showtime_pings(
     return list(session.exec(stmt).all())
 
 
+def get_received_pings_for_showtime(
+    *,
+    session: Session,
+    showtime_id: int,
+    receiver_id: UUID,
+) -> list[tuple[ShowtimePing, User]]:
+    """Active (non-dismissed) received pings for a showtime, with sender, newest first."""
+    stmt = (
+        select(ShowtimePing, User)
+        .join(User, col(User.id) == col(ShowtimePing.sender_id))
+        .where(
+            ShowtimePing.showtime_id == showtime_id,
+            ShowtimePing.receiver_id == receiver_id,
+            col(ShowtimePing.dismissed_at).is_(None),
+        )
+        .order_by(col(ShowtimePing.created_at).desc())
+    )
+    return list(session.exec(stmt).all())  # type: ignore[return-value]
+
+
 def get_unseen_showtime_ping_count(
     *,
     session: Session,

--- a/backend/app/schemas/showtime.py
+++ b/backend/app/schemas/showtime.py
@@ -36,6 +36,10 @@ class ShowtimeLoggedIn(ShowtimeBase):
     going: GoingStatus
     seat_row: str | None = None
     seat_number: str | None = None
+    # Unique senders of the current user's active (non-dismissed) received pings
+    # for this showtime, plus those pings' ids (used to dismiss the invite).
+    invited_by: Sequence["UserPublic"] = []
+    invite_ping_ids: Sequence[int] = []
 
 
 # For responses inside of a Movie model
@@ -47,3 +51,5 @@ class ShowtimeInMovieLoggedIn(ShowtimeBase):
     going: GoingStatus
     seat_row: str | None = None
     seat_number: str | None = None
+    invited_by: Sequence["UserPublic"] = []
+    invite_ping_ids: Sequence[int] = []

--- a/backend/app/services/me.py
+++ b/backend/app/services/me.py
@@ -998,6 +998,35 @@ def get_received_showtime_pings(
     return result
 
 
+def get_agenda_showtimes(
+    *,
+    session: Session,
+    user_id: UUID,
+    snapshot_time: datetime,
+    include_interested: bool,
+    include_invited: bool,
+    limit: int,
+    offset: int,
+) -> list[ShowtimeLoggedIn]:
+    showtimes = showtimes_crud.get_agenda_showtimes(
+        session=session,
+        user_id=user_id,
+        snapshot_time=snapshot_time,
+        include_interested=include_interested,
+        include_invited=include_invited,
+        limit=limit,
+        offset=offset,
+    )
+    return [
+        showtime_converters.to_logged_in(
+            showtime=showtime,
+            session=session,
+            user_id=user_id,
+        )
+        for showtime in showtimes
+    ]
+
+
 def get_unseen_showtime_ping_count(
     *,
     session: Session,

--- a/backend/tests/api/test_me.py
+++ b/backend/tests/api/test_me.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.core.config import settings
+from app.core.enums import GoingStatus
 from app.crud import friendship as friendship_crud
 from app.models.cinema_selection import CinemaSelection
 from app.models.friend_group import FriendGroup, FriendGroupMember
@@ -490,6 +491,9 @@ def test_showtime_pings_endpoints(
     assert pings[0]["showtime"]["movie"]["id"] == showtime.movie_id
     assert pings[0]["sender"]["id"] == str(sender.id)
     assert pings[0]["seen_at"] is None
+    # The nested showtime carries invite info for the receiver.
+    assert [u["id"] for u in pings[0]["showtime"]["invited_by"]] == [str(sender.id)]
+    assert pings[0]["showtime"]["invite_ping_ids"] == [ping.id]
 
     unseen_count_response = client.get(
         f"{settings.API_V1_STR}/me/pings/unseen-count",
@@ -510,6 +514,192 @@ def test_showtime_pings_endpoints(
     )
     assert unseen_count_after_mark_response.status_code == 200
     assert unseen_count_after_mark_response.json() == 0
+
+
+def test_get_my_agenda(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+    db_transaction: Session,
+    user_factory,
+    showtime_factory,
+) -> None:
+    receiver_id = _normal_user_id(db_transaction)
+    sender = user_factory()
+
+    going_showtime = showtime_factory()
+    interested_showtime = showtime_factory()
+    invited_showtime = showtime_factory()
+    unrelated_showtime = showtime_factory()
+    sender_id = sender.id
+    going_id = going_showtime.id
+    interested_id = interested_showtime.id
+    invited_id = invited_showtime.id
+    unrelated_id = unrelated_showtime.id
+
+    db_transaction.add(
+        ShowtimeSelection(
+            showtime_id=going_id,
+            user_id=receiver_id,
+            going_status=GoingStatus.GOING,
+        )
+    )
+    db_transaction.add(
+        ShowtimeSelection(
+            showtime_id=interested_id,
+            user_id=receiver_id,
+            going_status=GoingStatus.INTERESTED,
+        )
+    )
+    db_transaction.add(
+        ShowtimePing(
+            showtime_id=invited_id,
+            sender_id=sender_id,
+            receiver_id=receiver_id,
+            created_at=now_amsterdam_naive(),
+        )
+    )
+    db_transaction.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/me/agenda",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 200
+    agenda = response.json()
+    by_id = {item["id"]: item for item in agenda}
+
+    assert going_id in by_id
+    assert interested_id in by_id
+    assert invited_id in by_id
+    assert unrelated_id not in by_id
+
+    assert by_id[going_id]["going"] == "GOING"
+    assert by_id[interested_id]["going"] == "INTERESTED"
+
+    invited_item = by_id[invited_id]
+    assert invited_item["going"] == "NOT_GOING"
+    assert [u["id"] for u in invited_item["invited_by"]] == [str(sender_id)]
+    assert len(invited_item["invite_ping_ids"]) == 1
+
+    # Showtimes ordered by datetime ascending.
+    datetimes = [item["datetime"] for item in agenda]
+    assert datetimes == sorted(datetimes)
+
+
+def test_get_my_agenda_toggles(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+    db_transaction: Session,
+    user_factory,
+    showtime_factory,
+) -> None:
+    receiver_id = _normal_user_id(db_transaction)
+    sender = user_factory()
+
+    going_showtime = showtime_factory()
+    interested_showtime = showtime_factory()
+    invited_showtime = showtime_factory()
+    going_id = going_showtime.id
+    interested_id = interested_showtime.id
+    invited_id = invited_showtime.id
+
+    db_transaction.add(
+        ShowtimeSelection(
+            showtime_id=going_id,
+            user_id=receiver_id,
+            going_status=GoingStatus.GOING,
+        )
+    )
+    db_transaction.add(
+        ShowtimeSelection(
+            showtime_id=interested_id,
+            user_id=receiver_id,
+            going_status=GoingStatus.INTERESTED,
+        )
+    )
+    db_transaction.add(
+        ShowtimePing(
+            showtime_id=invited_id,
+            sender_id=sender.id,
+            receiver_id=receiver_id,
+            created_at=now_amsterdam_naive(),
+        )
+    )
+    db_transaction.commit()
+
+    # Hide interested → going + invited remain.
+    response = client.get(
+        f"{settings.API_V1_STR}/me/agenda",
+        headers=normal_user_token_headers,
+        params={"include_interested": False},
+    )
+    ids = {item["id"] for item in response.json()}
+    assert going_id in ids
+    assert invited_id in ids
+    assert interested_id not in ids
+
+    # Hide invites → going + interested remain.
+    response = client.get(
+        f"{settings.API_V1_STR}/me/agenda",
+        headers=normal_user_token_headers,
+        params={"include_invited": False},
+    )
+    ids = {item["id"] for item in response.json()}
+    assert going_id in ids
+    assert interested_id in ids
+    assert invited_id not in ids
+
+    # Hide both → only going remains.
+    response = client.get(
+        f"{settings.API_V1_STR}/me/agenda",
+        headers=normal_user_token_headers,
+        params={"include_interested": False, "include_invited": False},
+    )
+    ids = {item["id"] for item in response.json()}
+    assert ids == {going_id}
+
+
+def test_get_my_agenda_excludes_past_and_dismissed(
+    client: TestClient,
+    normal_user_token_headers: dict[str, str],
+    db_transaction: Session,
+    user_factory,
+    showtime_factory,
+) -> None:
+    receiver_id = _normal_user_id(db_transaction)
+    sender = user_factory()
+
+    past_showtime = showtime_factory(datetime=now_amsterdam_naive() - timedelta(days=2))
+    dismissed_invite_showtime = showtime_factory()
+    past_id = past_showtime.id
+    dismissed_id = dismissed_invite_showtime.id
+
+    db_transaction.add(
+        ShowtimeSelection(
+            showtime_id=past_id,
+            user_id=receiver_id,
+            going_status=GoingStatus.GOING,
+        )
+    )
+    db_transaction.add(
+        ShowtimePing(
+            showtime_id=dismissed_id,
+            sender_id=sender.id,
+            receiver_id=receiver_id,
+            created_at=now_amsterdam_naive(),
+            dismissed_at=now_amsterdam_naive(),
+        )
+    )
+    db_transaction.commit()
+
+    response = client.get(
+        f"{settings.API_V1_STR}/me/agenda",
+        headers=normal_user_token_headers,
+    )
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.json()}
+    assert past_id not in ids
+    assert dismissed_id not in ids
 
 
 def test_delete_showtime_ping_endpoint(

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -61,6 +61,8 @@ import type {
   MeCountMyShowtimesResponse,
   MeGetMyShowtimesData,
   MeGetMyShowtimesResponse,
+  MeGetMyAgendaData,
+  MeGetMyAgendaResponse,
   MeGetMyShowtimePingsData,
   MeGetMyShowtimePingsResponse,
   MeGetMyUnseenShowtimePingCountResponse,
@@ -808,6 +810,36 @@ export class MeService {
         selected_statuses: data.selectedStatuses,
         runtime_min: data.runtimeMin,
         runtime_max: data.runtimeMax,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Get My Agenda
+   * @param data The data for the request.
+   * @param data.includeInterested
+   * @param data.includeInvited
+   * @param data.snapshotTime Only show showtimes after this moment
+   * @param data.limit
+   * @param data.offset
+   * @returns ShowtimeLoggedIn Successful Response
+   * @throws ApiError
+   */
+  public static getMyAgenda(
+    data: MeGetMyAgendaData = {},
+  ): CancelablePromise<MeGetMyAgendaResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/me/agenda",
+      query: {
+        include_interested: data.includeInterested,
+        include_invited: data.includeInvited,
+        snapshot_time: data.snapshotTime,
+        limit: data.limit,
+        offset: data.offset,
       },
       errors: {
         422: "Validation Error",

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -220,6 +220,8 @@ export type ShowtimeInMovieLoggedIn = {
   going: GoingStatus
   seat_row?: string | null
   seat_number?: string | null
+  invited_by?: Array<UserPublic>
+  invite_ping_ids?: Array<number>
 }
 
 export type ShowtimeLoggedIn = {
@@ -235,6 +237,8 @@ export type ShowtimeLoggedIn = {
   going: GoingStatus
   seat_row?: string | null
   seat_number?: string | null
+  invited_by?: Array<UserPublic>
+  invite_ping_ids?: Array<number>
 }
 
 export type ShowtimePingPublic = {
@@ -602,6 +606,19 @@ export type MeGetMyShowtimesData = {
 }
 
 export type MeGetMyShowtimesResponse = Array<ShowtimeLoggedIn>
+
+export type MeGetMyAgendaData = {
+  includeInterested?: boolean
+  includeInvited?: boolean
+  limit?: number
+  offset?: number
+  /**
+   * Only show showtimes after this moment
+   */
+  snapshotTime?: string | null
+}
+
+export type MeGetMyAgendaResponse = Array<ShowtimeLoggedIn>
 
 export type MeGetMyShowtimePingsData = {
   limit?: number


### PR DESCRIPTION
## Summary
Backend support for the mobile Agenda tab and invite-aware showtimes.

- Add `invited_by` / `invite_ping_ids` to `ShowtimeLoggedIn` and `ShowtimeInMovieLoggedIn`, populated from the current user's active (non-dismissed) received pings in the showtime converter. This lets every surface that renders a showtime know whether *you* were invited (for blue color-coding and always showing invite info in the modal).
- Add `get_received_pings_for_showtime` CRUD.
- Add `GET /me/agenda`: upcoming showtimes you're **going** to (always), **interested** in (`include_interested`, default true), or **invited** to (`include_invited`, default true). Ordered by datetime; the include flags are server-side query params so pagination stays correct.

## Tests
- `/me/agenda`: going-always, interested/invited toggles, past + dismissed exclusion, invite fields on the nested ping showtime.
- Full suite: 194 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)