### PR TITLE
feat(presets): SavedPreset model + /me/saved-presets API

### DIFF
--- a/backend/app/alembic/versions/a3f9c1e7b205_add_saved_presets.py
+++ b/backend/app/alembic/versions/a3f9c1e7b205_add_saved_presets.py
@@ -1,0 +1,74 @@
+"""Add saved presets table.
+
+A ``SavedPreset`` stores a partial filter selection (``included_fields`` +
+``filters``) plus an optional cinema selection (``cinema_ids``). It is additive:
+the legacy ``filterpreset`` and ``cinemapreset`` tables are left untouched.
+
+Revision ID: a3f9c1e7b205
+Revises: d7e8f9a0b1c2
+Create Date: 2026-06-04 13:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a3f9c1e7b205"
+down_revision = "d7e8f9a0b1c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "savedpreset",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=80), nullable=False),
+        sa.Column(
+            "scope",
+            sa.Enum("SHOWTIMES", "MOVIES", name="filterpresetscope", native_enum=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "is_favorite", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("included_fields", sa.JSON(), nullable=False),
+        sa.Column("filters", sa.JSON(), nullable=False),
+        sa.Column("cinema_ids", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["owner_user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "owner_user_id",
+            "scope",
+            "name",
+            name="uq_saved_preset_owner_scope_name",
+        ),
+    )
+    op.create_index(
+        op.f("ix_savedpreset_is_favorite"), "savedpreset", ["is_favorite"], unique=False
+    )
+    op.create_index(
+        op.f("ix_savedpreset_owner_user_id"),
+        "savedpreset",
+        ["owner_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_savedpreset_scope"), "savedpreset", ["scope"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_savedpreset_scope"), table_name="savedpreset")
+    op.drop_index(op.f("ix_savedpreset_owner_user_id"), table_name="savedpreset")
+    op.drop_index(op.f("ix_savedpreset_is_favorite"), table_name="savedpreset")
+    op.drop_table("savedpreset")

--- a/backend/app/api/routes/me.py
+++ b/backend/app/api/routes/me.py
@@ -24,6 +24,7 @@ from app.schemas.cinema_preset import CinemaPresetCreate, CinemaPresetPublic
 from app.schemas.filter_preset import FilterPresetCreate, FilterPresetPublic
 from app.schemas.friend_group import FriendGroupCreate, FriendGroupPublic
 from app.schemas.push_token import PushTokenDelete, PushTokenRegister
+from app.schemas.saved_preset import SavedPresetCreate, SavedPresetPublic
 from app.schemas.showtime import ShowtimeLoggedIn
 from app.schemas.showtime_ping import ShowtimePingPublic
 from app.schemas.user import UserMe, UserWithFriendStatus
@@ -134,6 +135,102 @@ def delete_filter_preset(
             detail="Filter preset not found",
         )
     return Message(message="Filter preset deleted successfully")
+
+
+@router.get("/saved-presets", response_model=list[SavedPresetPublic])
+def get_saved_presets(
+    session: SessionDep,
+    current_user: CurrentUser,
+    scope: FilterPresetScope = Query(...),
+) -> list[SavedPresetPublic]:
+    return me_service.list_saved_presets(
+        session=session,
+        user_id=current_user.id,
+        scope=scope,
+    )
+
+
+@router.post("/saved-presets", response_model=SavedPresetPublic)
+def create_saved_preset(
+    session: SessionDep,
+    current_user: CurrentUser,
+    payload: SavedPresetCreate,
+) -> SavedPresetPublic:
+    if not payload.name.strip():
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail="Preset name cannot be empty",
+        )
+    return me_service.save_saved_preset(
+        session=session,
+        user_id=current_user.id,
+        payload=payload,
+    )
+
+
+@router.get("/saved-presets/favorite", response_model=SavedPresetPublic | None)
+def get_favorite_saved_preset(
+    session: SessionDep,
+    current_user: CurrentUser,
+    scope: FilterPresetScope = Query(...),
+) -> SavedPresetPublic | None:
+    return me_service.get_favorite_saved_preset(
+        session=session,
+        user_id=current_user.id,
+        scope=scope,
+    )
+
+
+@router.put("/saved-presets/{preset_id}/favorite", response_model=SavedPresetPublic)
+def set_favorite_saved_preset(
+    session: SessionDep,
+    current_user: CurrentUser,
+    preset_id: UUID,
+) -> SavedPresetPublic:
+    favorite = me_service.set_favorite_saved_preset(
+        session=session,
+        user_id=current_user.id,
+        preset_id=preset_id,
+    )
+    if favorite is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Saved preset not found",
+        )
+    return favorite
+
+
+@router.delete("/saved-presets/favorite", response_model=Message)
+def clear_favorite_saved_preset(
+    session: SessionDep,
+    current_user: CurrentUser,
+    scope: FilterPresetScope = Query(...),
+) -> Message:
+    me_service.clear_favorite_saved_preset(
+        session=session,
+        user_id=current_user.id,
+        scope=scope,
+    )
+    return Message(message="Favorite saved preset cleared successfully")
+
+
+@router.delete("/saved-presets/{preset_id}", response_model=Message)
+def delete_saved_preset(
+    session: SessionDep,
+    current_user: CurrentUser,
+    preset_id: UUID,
+) -> Message:
+    deleted = me_service.delete_saved_preset(
+        session=session,
+        user_id=current_user.id,
+        preset_id=preset_id,
+    )
+    if not deleted:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="Saved preset not found",
+        )
+    return Message(message="Saved preset deleted successfully")
 
 
 @router.get("/cinema-presets", response_model=list[CinemaPresetPublic])

--- a/backend/app/crud/saved_preset.py
+++ b/backend/app/crud/saved_preset.py
@@ -1,0 +1,171 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlmodel import Session, col, select
+
+from app.core.enums import FilterPresetScope
+from app.models.saved_preset import SavedPreset
+
+
+def list_user_presets(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> list[SavedPreset]:
+    stmt = (
+        select(SavedPreset)
+        .where(
+            col(SavedPreset.owner_user_id) == user_id,
+            col(SavedPreset.scope) == scope,
+        )
+        .order_by(
+            col(SavedPreset.is_favorite).desc(),
+            func.lower(col(SavedPreset.name)),
+            col(SavedPreset.created_at),
+        )
+    )
+    return list(session.exec(stmt).all())
+
+
+def get_user_preset_by_name(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+    name: str,
+) -> SavedPreset | None:
+    stmt = select(SavedPreset).where(
+        col(SavedPreset.owner_user_id) == user_id,
+        col(SavedPreset.scope) == scope,
+        col(SavedPreset.name) == name,
+    )
+    return session.exec(stmt).one_or_none()
+
+
+def get_user_preset_by_id(
+    *,
+    session: Session,
+    user_id: UUID,
+    preset_id: UUID,
+) -> SavedPreset | None:
+    stmt = select(SavedPreset).where(
+        col(SavedPreset.id) == preset_id,
+        col(SavedPreset.owner_user_id) == user_id,
+    )
+    return session.exec(stmt).one_or_none()
+
+
+def get_user_favorite_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> SavedPreset | None:
+    stmt = select(SavedPreset).where(
+        col(SavedPreset.owner_user_id) == user_id,
+        col(SavedPreset.scope) == scope,
+        col(SavedPreset.is_favorite).is_(True),
+    )
+    return session.exec(stmt).one_or_none()
+
+
+def create_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    name: str,
+    scope: FilterPresetScope,
+    included_fields: list[str],
+    filters: dict[str, Any],
+    cinema_ids: list[int] | None,
+    is_favorite: bool,
+    now: datetime,
+) -> SavedPreset:
+    preset = SavedPreset(
+        owner_user_id=user_id,
+        name=name,
+        scope=scope,
+        is_favorite=is_favorite,
+        included_fields=included_fields,
+        filters=filters,
+        cinema_ids=cinema_ids,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(preset)
+    session.flush()
+    return preset
+
+
+def update_preset(
+    *,
+    session: Session,
+    preset: SavedPreset,
+    included_fields: list[str],
+    filters: dict[str, Any],
+    cinema_ids: list[int] | None,
+    is_favorite: bool | None,
+    now: datetime,
+) -> SavedPreset:
+    preset.included_fields = included_fields
+    preset.filters = filters
+    preset.cinema_ids = cinema_ids
+    if is_favorite is not None:
+        preset.is_favorite = is_favorite
+    preset.updated_at = now
+    session.add(preset)
+    session.flush()
+    return preset
+
+
+def clear_user_favorite_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> None:
+    stmt = select(SavedPreset).where(
+        col(SavedPreset.owner_user_id) == user_id,
+        col(SavedPreset.scope) == scope,
+        col(SavedPreset.is_favorite).is_(True),
+    )
+    presets = list(session.exec(stmt).all())
+    for preset in presets:
+        preset.is_favorite = False
+        session.add(preset)
+    session.flush()
+
+
+def set_preset_favorite(
+    *,
+    session: Session,
+    preset: SavedPreset,
+    is_favorite: bool,
+    now: datetime,
+) -> SavedPreset:
+    preset.is_favorite = is_favorite
+    preset.updated_at = now
+    session.add(preset)
+    session.flush()
+    return preset
+
+
+def delete_user_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    preset_id: UUID,
+) -> bool:
+    preset = get_user_preset_by_id(
+        session=session,
+        user_id=user_id,
+        preset_id=preset_id,
+    )
+    if preset is None:
+        return False
+    session.delete(preset)
+    session.flush()
+    return True

--- a/backend/app/models/saved_preset.py
+++ b/backend/app/models/saved_preset.py
@@ -1,0 +1,64 @@
+"""Saved preset model — user-saved, partial filter + cinema configurations.
+
+Unlike the legacy :class:`~app.models.filter_preset.FilterPreset` (which always
+stores the *full* filter set and is applied as a complete replacement), a
+``SavedPreset`` records only the dimensions the user chose to include
+(``included_fields``) plus an optional cinema selection. Applying one sets only
+those dimensions and leaves every other active filter untouched.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, UniqueConstraint
+from sqlalchemy import Enum as SAEnum
+from sqlmodel import Column, Field, SQLModel
+
+from app.core.enums import FilterPresetScope
+from app.utils import now_amsterdam_naive
+
+
+class SavedPreset(SQLModel, table=True):
+    __table_args__ = (
+        UniqueConstraint(
+            "owner_user_id",
+            "scope",
+            "name",
+            name="uq_saved_preset_owner_scope_name",
+        ),
+    )
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_user_id: uuid.UUID = Field(
+        foreign_key="user.id",
+        ondelete="CASCADE",
+        index=True,
+    )
+    name: str = Field(max_length=80)
+    scope: FilterPresetScope = Field(
+        sa_column=Column(
+            SAEnum(FilterPresetScope, native_enum=False), nullable=False, index=True
+        ),
+    )
+    is_favorite: bool = Field(default=False, nullable=False, index=True)
+    # Which dimensions this preset applies. Tokens come from
+    # ``app.schemas.saved_preset.INCLUDABLE_FIELDS``.
+    included_fields: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON, nullable=False),
+    )
+    # Full filter snapshot; only the keys named in ``included_fields`` are
+    # meaningful when applying. Non-included keys are ignored.
+    filters: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    # Cinema selection, only meaningful when "cinemas" is in ``included_fields``.
+    # ``None`` means the preset does not touch the cinema selection.
+    cinema_ids: list[int] | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+    )
+    created_at: datetime = Field(default_factory=now_amsterdam_naive, nullable=False)
+    updated_at: datetime = Field(default_factory=now_amsterdam_naive, nullable=False)

--- a/backend/app/schemas/saved_preset.py
+++ b/backend/app/schemas/saved_preset.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import field_validator, model_validator
+from sqlmodel import Field, SQLModel
+
+from app.core.enums import FilterPresetScope
+from app.schemas.filter_preset import FilterPresetFilters
+
+__all__ = [
+    "INCLUDABLE_FIELDS",
+    "CINEMAS_FIELD",
+    "SavedPresetCreate",
+    "SavedPresetPublic",
+]
+
+# Token used in ``included_fields`` to mark that the preset carries a cinema
+# selection (stored in ``cinema_ids`` rather than in ``filters``).
+CINEMAS_FIELD = "cinemas"
+
+# The dimensions a saved preset may apply. The filter-shaped tokens map 1:1 to
+# fields on :class:`FilterPresetFilters`; ``cinemas`` maps to ``cinema_ids``.
+INCLUDABLE_FIELDS = frozenset(
+    {
+        "selected_showtime_filter",
+        "showtime_audience",
+        "watchlist_only",
+        "days",
+        "time_ranges",
+        "runtime_ranges",
+        CINEMAS_FIELD,
+    }
+)
+
+INCLUDED_FIELDS_VALIDATION_ERROR = (
+    "included_fields must be a non-empty subset of: "
+    + ", ".join(sorted(INCLUDABLE_FIELDS))
+)
+
+
+class SavedPresetCreate(SQLModel):
+    name: str = Field(min_length=1, max_length=80)
+    scope: FilterPresetScope
+    included_fields: list[str]
+    filters: FilterPresetFilters
+    cinema_ids: list[int] | None = None
+    is_favorite: bool | None = None
+
+    @field_validator("included_fields")
+    @classmethod
+    def validate_included_fields(cls, values: list[str]) -> list[str]:
+        deduped = list(dict.fromkeys(values))
+        if not deduped or any(value not in INCLUDABLE_FIELDS for value in deduped):
+            raise ValueError(INCLUDED_FIELDS_VALIDATION_ERROR)
+        return deduped
+
+    @model_validator(mode="after")
+    def reconcile_cinema_ids(self) -> "SavedPresetCreate":
+        if CINEMAS_FIELD in self.included_fields:
+            if self.cinema_ids is None:
+                raise ValueError(
+                    'cinema_ids is required when "cinemas" is in included_fields'
+                )
+            self.cinema_ids = sorted(set(self.cinema_ids))
+        else:
+            # Cinema not part of this preset — never persist a stray selection.
+            self.cinema_ids = None
+        return self
+
+
+class SavedPresetPublic(SQLModel):
+    id: UUID
+    name: str
+    scope: FilterPresetScope
+    is_favorite: bool
+    included_fields: list[str]
+    filters: FilterPresetFilters
+    cinema_ids: list[int] | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/me.py
+++ b/backend/app/services/me.py
@@ -14,6 +14,7 @@ from app.crud import cinema_preset as cinema_presets_crud
 from app.crud import filter_preset as filter_presets_crud
 from app.crud import friend_group as friend_groups_crud
 from app.crud import push_token as push_tokens_crud
+from app.crud import saved_preset as saved_presets_crud
 from app.crud import showtime as showtimes_crud
 from app.crud import showtime_ping as showtime_ping_crud
 from app.crud import showtime_visibility as showtime_visibility_crud
@@ -28,11 +29,13 @@ from app.models.cinema_preset import CinemaPreset
 from app.models.filter_preset import FilterPreset
 from app.models.friend_group import FriendGroup
 from app.models.push_token import PushToken
+from app.models.saved_preset import SavedPreset
 from app.models.showtime import Showtime
 from app.models.user import User, UserUpdate
 from app.schemas.cinema_preset import CinemaPresetCreate, CinemaPresetPublic
 from app.schemas.filter_preset import FilterPresetCreate, FilterPresetPublic
 from app.schemas.friend_group import FriendGroupCreate, FriendGroupPublic
+from app.schemas.saved_preset import SavedPresetCreate, SavedPresetPublic
 from app.schemas.showtime import ShowtimeLoggedIn
 from app.schemas.showtime_ping import ShowtimePingPublic
 from app.schemas.user import UserMe
@@ -339,6 +342,164 @@ def clear_favorite_filter_preset(
     scope: FilterPresetScope,
 ) -> None:
     filter_presets_crud.clear_user_favorite_preset(
+        session=session,
+        user_id=user_id,
+        scope=scope,
+    )
+    session.commit()
+
+
+def _to_saved_preset_public(preset: SavedPreset) -> SavedPresetPublic:
+    return SavedPresetPublic.model_validate(
+        {
+            "id": preset.id,
+            "name": preset.name,
+            "scope": preset.scope,
+            "is_favorite": preset.is_favorite,
+            "included_fields": preset.included_fields,
+            "filters": preset.filters,
+            "cinema_ids": preset.cinema_ids,
+            "created_at": preset.created_at,
+            "updated_at": preset.updated_at,
+        }
+    )
+
+
+def list_saved_presets(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> list[SavedPresetPublic]:
+    presets = saved_presets_crud.list_user_presets(
+        session=session,
+        user_id=user_id,
+        scope=scope,
+    )
+    return [_to_saved_preset_public(preset) for preset in presets]
+
+
+def save_saved_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    payload: SavedPresetCreate,
+) -> SavedPresetPublic:
+    now = now_amsterdam_naive()
+    preset_name = payload.name.strip()
+    filters = payload.filters.model_dump(mode="json")
+    cinema_ids = list(payload.cinema_ids) if payload.cinema_ids is not None else None
+    should_set_favorite = payload.is_favorite is True
+    existing = saved_presets_crud.get_user_preset_by_name(
+        session=session,
+        user_id=user_id,
+        scope=payload.scope,
+        name=preset_name,
+    )
+
+    if should_set_favorite:
+        saved_presets_crud.clear_user_favorite_preset(
+            session=session,
+            user_id=user_id,
+            scope=payload.scope,
+        )
+
+    if existing is None:
+        preset = saved_presets_crud.create_preset(
+            session=session,
+            user_id=user_id,
+            name=preset_name,
+            scope=payload.scope,
+            included_fields=payload.included_fields,
+            filters=filters,
+            cinema_ids=cinema_ids,
+            is_favorite=should_set_favorite,
+            now=now,
+        )
+    else:
+        preset = saved_presets_crud.update_preset(
+            session=session,
+            preset=existing,
+            included_fields=payload.included_fields,
+            filters=filters,
+            cinema_ids=cinema_ids,
+            is_favorite=payload.is_favorite,
+            now=now,
+        )
+
+    session.commit()
+    return _to_saved_preset_public(preset)
+
+
+def delete_saved_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    preset_id: UUID,
+) -> bool:
+    deleted = saved_presets_crud.delete_user_preset(
+        session=session,
+        user_id=user_id,
+        preset_id=preset_id,
+    )
+    if deleted:
+        session.commit()
+    return deleted
+
+
+def get_favorite_saved_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> SavedPresetPublic | None:
+    preset = saved_presets_crud.get_user_favorite_preset(
+        session=session,
+        user_id=user_id,
+        scope=scope,
+    )
+    if preset is None:
+        return None
+    return _to_saved_preset_public(preset)
+
+
+def set_favorite_saved_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    preset_id: UUID,
+) -> SavedPresetPublic | None:
+    now = now_amsterdam_naive()
+    preset = saved_presets_crud.get_user_preset_by_id(
+        session=session,
+        user_id=user_id,
+        preset_id=preset_id,
+    )
+    if preset is None:
+        return None
+
+    saved_presets_crud.clear_user_favorite_preset(
+        session=session,
+        user_id=user_id,
+        scope=preset.scope,
+    )
+    favorite = saved_presets_crud.set_preset_favorite(
+        session=session,
+        preset=preset,
+        is_favorite=True,
+        now=now,
+    )
+    session.commit()
+    return _to_saved_preset_public(favorite)
+
+
+def clear_favorite_saved_preset(
+    *,
+    session: Session,
+    user_id: UUID,
+    scope: FilterPresetScope,
+) -> None:
+    saved_presets_crud.clear_user_favorite_preset(
         session=session,
         user_id=user_id,
         scope=scope,

--- a/backend/tests/api/test_me.py
+++ b/backend/tests/api/test_me.py
@@ -194,7 +194,9 @@ def test_delete_me_removes_user_and_related_rows(
     )
     assert (
         db_transaction.exec(
-            select(FriendGroupMember).where(FriendGroupMember.group_id == friend_group_id)
+            select(FriendGroupMember).where(
+                FriendGroupMember.group_id == friend_group_id
+            )
         ).one_or_none()
         is None
     )
@@ -234,7 +236,9 @@ def test_delete_push_token_for_current_user(
 ) -> None:
     current_user_id = _normal_user_id(db_transaction)
     test_token = f"delete-token-{current_user_id}"
-    db_transaction.add(PushToken(token=test_token, user_id=current_user_id, platform="android"))
+    db_transaction.add(
+        PushToken(token=test_token, user_id=current_user_id, platform="android")
+    )
     db_transaction.commit()
 
     response = client.request(
@@ -250,7 +254,9 @@ def test_delete_push_token_for_current_user(
     assert response.json()["message"] == "Push token deleted successfully"
 
     assert (
-        db_transaction.exec(select(PushToken).where(PushToken.token == test_token)).one_or_none()
+        db_transaction.exec(
+            select(PushToken).where(PushToken.token == test_token)
+        ).one_or_none()
         is None
     )
 
@@ -1174,6 +1180,191 @@ def test_filter_preset_can_be_marked_as_favorite(
     )
     assert favorite_after_clear.status_code == 200
     assert favorite_after_clear.json() is None
+
+
+def test_saved_presets_store_partial_fields_and_cinemas(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    # A days-only preset that also pins a cinema selection.
+    days_payload = {
+        "name": "Weekend at the Local",
+        "scope": "SHOWTIMES",
+        "included_fields": ["days", "cinemas"],
+        "filters": {
+            "selected_showtime_filter": "going",
+            "watchlist_only": True,
+            "days": ["2026-02-21", "2026-02-22"],
+            "time_ranges": ["18:00-21:59"],
+        },
+        "cinema_ids": [3, 1, 1, 2],
+    }
+    create = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json=days_payload,
+    )
+    assert create.status_code == 200
+    body = create.json()
+    assert body["included_fields"] == ["days", "cinemas"]
+    # cinema_ids are normalized (deduped + sorted).
+    assert body["cinema_ids"] == [1, 2, 3]
+    # The full filter snapshot is preserved; the frontend applies only the
+    # included dimensions.
+    assert body["filters"]["days"] == ["2026-02-21", "2026-02-22"]
+    assert body["filters"]["selected_showtime_filter"] == "going"
+    assert body["is_favorite"] is False
+
+    # Listing is scoped and returns no synthetic "Default" preset.
+    showtimes_list = client.get(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        params={"scope": "SHOWTIMES"},
+    )
+    assert showtimes_list.status_code == 200
+    presets = showtimes_list.json()
+    assert [preset["name"] for preset in presets] == ["Weekend at the Local"]
+
+    movies_list = client.get(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        params={"scope": "MOVIES"},
+    )
+    assert movies_list.status_code == 200
+    assert movies_list.json() == []
+
+
+def test_saved_preset_without_cinemas_field_drops_cinema_ids(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    payload = {
+        "name": "Just Status",
+        "scope": "SHOWTIMES",
+        "included_fields": ["selected_showtime_filter"],
+        "filters": {"selected_showtime_filter": "interested"},
+        # cinema_ids supplied but "cinemas" not included -> must be discarded.
+        "cinema_ids": [1, 2],
+    }
+    create = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json=payload,
+    )
+    assert create.status_code == 200
+    assert create.json()["cinema_ids"] is None
+
+
+def test_saved_preset_validation_errors(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    base = {
+        "name": "Bad",
+        "scope": "SHOWTIMES",
+        "filters": {},
+    }
+
+    # Empty included_fields is rejected.
+    empty = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={**base, "included_fields": []},
+    )
+    assert empty.status_code == 422
+
+    # Unknown token is rejected.
+    unknown = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={**base, "included_fields": ["not_a_real_field"]},
+    )
+    assert unknown.status_code == 422
+
+    # "cinemas" requires cinema_ids.
+    missing_cinemas = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={**base, "included_fields": ["cinemas"]},
+    )
+    assert missing_cinemas.status_code == 422
+
+
+def test_saved_preset_upsert_delete_and_favorite(
+    client: TestClient, normal_user_token_headers: dict[str, str]
+) -> None:
+    first = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={
+            "name": "Quick",
+            "scope": "SHOWTIMES",
+            "included_fields": ["time_ranges"],
+            "filters": {"time_ranges": ["18:00-21:59"]},
+        },
+    )
+    assert first.status_code == 200
+    first_id = first.json()["id"]
+
+    # Same (scope, name) upserts the existing row.
+    upsert = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={
+            "name": "Quick",
+            "scope": "SHOWTIMES",
+            "included_fields": ["days"],
+            "filters": {"days": ["2026-03-01"]},
+        },
+    )
+    assert upsert.status_code == 200
+    assert upsert.json()["id"] == first_id
+    assert upsert.json()["included_fields"] == ["days"]
+
+    second = client.post(
+        f"{settings.API_V1_STR}/me/saved-presets",
+        headers=normal_user_token_headers,
+        json={
+            "name": "Late",
+            "scope": "SHOWTIMES",
+            "included_fields": ["time_ranges"],
+            "filters": {"time_ranges": ["22:00-"]},
+            "is_favorite": True,
+        },
+    )
+    assert second.status_code == 200
+    second_id = second.json()["id"]
+    assert second.json()["is_favorite"] is True
+
+    favorite_get = client.get(
+        f"{settings.API_V1_STR}/me/saved-presets/favorite",
+        headers=normal_user_token_headers,
+        params={"scope": "SHOWTIMES"},
+    )
+    assert favorite_get.status_code == 200
+    assert favorite_get.json()["id"] == second_id
+
+    # Favoriting another preset clears the previous favorite within the scope.
+    refavorite = client.put(
+        f"{settings.API_V1_STR}/me/saved-presets/{first_id}/favorite",
+        headers=normal_user_token_headers,
+    )
+    assert refavorite.status_code == 200
+    favorite_after = client.get(
+        f"{settings.API_V1_STR}/me/saved-presets/favorite",
+        headers=normal_user_token_headers,
+        params={"scope": "SHOWTIMES"},
+    )
+    assert favorite_after.json()["id"] == first_id
+
+    delete = client.delete(
+        f"{settings.API_V1_STR}/me/saved-presets/{first_id}",
+        headers=normal_user_token_headers,
+    )
+    assert delete.status_code == 200
+
+    missing_delete = client.delete(
+        f"{settings.API_V1_STR}/me/saved-presets/{first_id}",
+        headers=normal_user_token_headers,
+    )
+    assert missing_delete.status_code == 404
 
 
 def test_cinema_presets_and_favorite_cinema_selection(

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -37,6 +37,18 @@ import type {
   MeSetFavoriteFilterPresetResponse,
   MeDeleteFilterPresetData,
   MeDeleteFilterPresetResponse,
+  MeGetSavedPresetsData,
+  MeGetSavedPresetsResponse,
+  MeCreateSavedPresetData,
+  MeCreateSavedPresetResponse,
+  MeGetFavoriteSavedPresetData,
+  MeGetFavoriteSavedPresetResponse,
+  MeClearFavoriteSavedPresetData,
+  MeClearFavoriteSavedPresetResponse,
+  MeSetFavoriteSavedPresetData,
+  MeSetFavoriteSavedPresetResponse,
+  MeDeleteSavedPresetData,
+  MeDeleteSavedPresetResponse,
   MeGetCinemaPresetsResponse,
   MeCreateCinemaPresetData,
   MeCreateCinemaPresetResponse,
@@ -500,6 +512,137 @@ export class MeService {
     return __request(OpenAPI, {
       method: "DELETE",
       url: "/api/v1/me/filter-presets/{preset_id}",
+      path: {
+        preset_id: data.presetId,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Get Saved Presets
+   * @param data The data for the request.
+   * @param data.scope
+   * @returns SavedPresetPublic Successful Response
+   * @throws ApiError
+   */
+  public static getSavedPresets(
+    data: MeGetSavedPresetsData,
+  ): CancelablePromise<MeGetSavedPresetsResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/me/saved-presets",
+      query: {
+        scope: data.scope,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Create Saved Preset
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns SavedPresetPublic Successful Response
+   * @throws ApiError
+   */
+  public static createSavedPreset(
+    data: MeCreateSavedPresetData,
+  ): CancelablePromise<MeCreateSavedPresetResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/me/saved-presets",
+      body: data.requestBody,
+      mediaType: "application/json",
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Get Favorite Saved Preset
+   * @param data The data for the request.
+   * @param data.scope
+   * @returns unknown Successful Response
+   * @throws ApiError
+   */
+  public static getFavoriteSavedPreset(
+    data: MeGetFavoriteSavedPresetData,
+  ): CancelablePromise<MeGetFavoriteSavedPresetResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/me/saved-presets/favorite",
+      query: {
+        scope: data.scope,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Clear Favorite Saved Preset
+   * @param data The data for the request.
+   * @param data.scope
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static clearFavoriteSavedPreset(
+    data: MeClearFavoriteSavedPresetData,
+  ): CancelablePromise<MeClearFavoriteSavedPresetResponse> {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/api/v1/me/saved-presets/favorite",
+      query: {
+        scope: data.scope,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Set Favorite Saved Preset
+   * @param data The data for the request.
+   * @param data.presetId
+   * @returns SavedPresetPublic Successful Response
+   * @throws ApiError
+   */
+  public static setFavoriteSavedPreset(
+    data: MeSetFavoriteSavedPresetData,
+  ): CancelablePromise<MeSetFavoriteSavedPresetResponse> {
+    return __request(OpenAPI, {
+      method: "PUT",
+      url: "/api/v1/me/saved-presets/{preset_id}/favorite",
+      path: {
+        preset_id: data.presetId,
+      },
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Delete Saved Preset
+   * @param data The data for the request.
+   * @param data.presetId
+   * @returns Message Successful Response
+   * @throws ApiError
+   */
+  public static deleteSavedPreset(
+    data: MeDeleteSavedPresetData,
+  ): CancelablePromise<MeDeleteSavedPresetResponse> {
+    return __request(OpenAPI, {
+      method: "DELETE",
+      url: "/api/v1/me/saved-presets/{preset_id}",
       path: {
         preset_id: data.presetId,
       },

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -199,6 +199,27 @@ export type PushTokenRegister = {
   platform?: "ios" | "android" | "web" | null
 }
 
+export type SavedPresetCreate = {
+  name: string
+  scope: FilterPresetScope
+  included_fields: Array<string>
+  filters: FilterPresetFilters
+  cinema_ids?: Array<number> | null
+  is_favorite?: boolean | null
+}
+
+export type SavedPresetPublic = {
+  id: string
+  name: string
+  scope: FilterPresetScope
+  is_favorite: boolean
+  included_fields: Array<string>
+  filters: FilterPresetFilters
+  cinema_ids: Array<number> | null
+  created_at: string
+  updated_at: string
+}
+
 export type SentShowtimePingPublic = {
   id: number
   receiver_id: string
@@ -484,6 +505,42 @@ export type MeDeleteFilterPresetData = {
 }
 
 export type MeDeleteFilterPresetResponse = Message
+
+export type MeGetSavedPresetsData = {
+  scope: FilterPresetScope
+}
+
+export type MeGetSavedPresetsResponse = Array<SavedPresetPublic>
+
+export type MeCreateSavedPresetData = {
+  requestBody: SavedPresetCreate
+}
+
+export type MeCreateSavedPresetResponse = SavedPresetPublic
+
+export type MeGetFavoriteSavedPresetData = {
+  scope: FilterPresetScope
+}
+
+export type MeGetFavoriteSavedPresetResponse = SavedPresetPublic | null
+
+export type MeClearFavoriteSavedPresetData = {
+  scope: FilterPresetScope
+}
+
+export type MeClearFavoriteSavedPresetResponse = Message
+
+export type MeSetFavoriteSavedPresetData = {
+  presetId: string
+}
+
+export type MeSetFavoriteSavedPresetResponse = SavedPresetPublic
+
+export type MeDeleteSavedPresetData = {
+  presetId: string
+}
+
+export type MeDeleteSavedPresetResponse = Message
 
 export type MeGetCinemaPresetsResponse = Array<CinemaPresetPublic>
 


### PR DESCRIPTION
## What

Adds a new **unified "saved preset"** backend that stores a *partial* filter selection plus an *optional cinema selection*, designed to be applied **additively** — applying a preset sets only the dimensions it includes and leaves every other active filter unchanged.

This is the backend foundation for the upcoming mobile filter-preset overhaul (save current filter state, choose which selections to include — including cinemas — then tap a preset to (de)populate the active filter chips).

## Design

Per discussion, this is implemented as a **new table**, kept strictly **additive**:
- The legacy `filterpreset` (full-replacement filter presets) and `cinemapreset` (separate cinema presets) systems are **left fully intact** for backwards compatibility — nothing existing is touched or migrated.
- New `SavedPreset`:
  - `included_fields: list[str]` — which dimensions the preset applies. Tokens: `selected_showtime_filter`, `showtime_audience`, `watchlist_only`, `days`, `time_ranges`, `runtime_ranges`, `cinemas`.
  - `filters` — full `FilterPresetFilters`-shaped snapshot (only included keys are meaningful on apply).
  - `cinema_ids: list[int] | null` — required & normalized (sorted/unique) when `cinemas` is included; forced `null` otherwise.
  - `scope` (SHOWTIMES/MOVIES) + `is_favorite` (≤1 favorite per scope), like the existing presets. No synthetic "Default" — the client shows an empty-state hint instead.

## Endpoints (`/me/saved-presets`)

- `GET /me/saved-presets?scope=` — list (scoped)
- `POST /me/saved-presets` — create/upsert by (scope, name)
- `GET /me/saved-presets/favorite?scope=`
- `PUT /me/saved-presets/{preset_id}/favorite`
- `DELETE /me/saved-presets/favorite?scope=`
- `DELETE /me/saved-presets/{preset_id}`

## Changes

- New `model` / `schema` / `crud` / service functions + routes.
- Alembic migration `a3f9c1e7b205` (down_revision `d7e8f9a0b1c2`) — creates `savedpreset`, no data migration.
- Tests in `test_me.py`: partial fields + cinema normalization, validation errors (empty/unknown tokens, `cinemas` without ids), upsert/delete, favorites/scoping.
- Regenerated shared client (`SavedPreset*` types + `MeService` methods) — additive.

## Verification (local)

- `ruff check` + `ruff format` clean; `mypy` clean on touched files.
- `pytest tests/api/test_me.py` — 36 passed (incl. 4 new saved-preset tests; migration exercised via `alembic upgrade head` in conftest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)