### PR TITLE
fix(presets): add group_by_movie to SavedPreset INCLUDABLE_FIELDS

### DIFF
--- a/backend/app/schemas/saved_preset.py
+++ b/backend/app/schemas/saved_preset.py
@@ -28,6 +28,7 @@ INCLUDABLE_FIELDS = frozenset(
         "days",
         "time_ranges",
         "runtime_ranges",
+        "group_by_movie",
         CINEMAS_FIELD,
     }
 )


### PR DESCRIPTION
## Summary
- `group_by_movie` was omitted from `INCLUDABLE_FIELDS` in the initial saved-presets PR (#265)
- Sending `included_fields: ["group_by_movie"]` to `POST /me/saved-presets` currently returns 422
- One-line fix: add `"group_by_movie"` to the frozenset

## Test plan
- [ ] Save a preset with only "Group by Movie" checked → should succeed (was 422)
- [ ] Existing preset saves without group_by_movie still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)