### PR TITLE
fix(presets): persist group_by_movie in FilterPresetFilters

### DIFF
--- a/backend/app/schemas/filter_preset.py
+++ b/backend/app/schemas/filter_preset.py
@@ -36,6 +36,7 @@ class FilterPresetFilters(SQLModel):
     days: list[str] | None = None
     time_ranges: list[str] | None = None
     runtime_ranges: list[str] | None = None
+    group_by_movie: bool | None = None
 
     @field_validator("days")
     @classmethod

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -86,6 +86,7 @@ export type FilterPresetFilters = {
   days?: Array<string> | null
   time_ranges?: Array<string> | null
   runtime_ranges?: Array<string> | null
+  group_by_movie?: boolean | null
 }
 
 export type showtime_audience = "including-friends" | "only-you"


### PR DESCRIPTION
## Problem

Saving a filter/saved preset with **group by movies** active stored it as **group by showtimes** — the value was silently lost.

Root cause is a schema gap on `master`:

- #267 added `group_by_movie` to `SavedPreset.INCLUDABLE_FIELDS`, so `included_fields: ["group_by_movie"]` is accepted.
- But `group_by_movie` was **never added to `FilterPresetFilters`** itself (the `filters` payload schema).

Pydantic ignores unknown input keys and `model_dump()` only emits declared fields, so the `filters.group_by_movie: true` sent by the client was dropped on save (`save_saved_preset` does `payload.filters.model_dump(mode="json")`) and came back absent on fetch → presets always applied as "group by showtimes".

## Fix

Add `group_by_movie: bool | None = None` to `FilterPresetFilters` so it round-trips through save and fetch. Verified `model_dump()` now emits the value instead of dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)