### PR TITLE
feat(auth): stateless refresh tokens

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -108,6 +108,15 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
             detail="Could not validate credentials",
         )
 
+    # Refresh tokens may only be exchanged at /login/refresh-token, never used as
+    # bearer credentials. (Older access tokens predate the "type" claim and have
+    # type=None, so they remain valid until they expire.)
+    if token_data.type == "refresh":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
+
     user = session.get(User, token_data.sub)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -12,27 +12,44 @@ from app.api.deps import SessionDep
 from app.core.config import settings
 from app.core.security import (
     create_access_token,
+    create_refresh_token,
+    decode_refresh_token,
     generate_password_reset_token,
     get_password_hash,
     verify_password_reset_token,
 )
 from app.crud import user as users_crud
 from app.mailer import EmailDeliveryError, generate_reset_password_email, send_email
-from app.models.auth_schemas import Message, NewPassword, Token
+from app.models.auth_schemas import Message, NewPassword, RefreshTokenRequest, Token
+from app.models.user import User
 
 router = APIRouter(tags=["login"])
 logger = logging.getLogger(__name__)
+
+
+def _build_token(user_id: object) -> Token:
+    """Issue a fresh access + refresh token pair for the given user ID."""
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    refresh_token_expires = timedelta(minutes=settings.REFRESH_TOKEN_EXPIRE_MINUTES)
+    return Token(
+        access_token=create_access_token(user_id, expires_delta=access_token_expires),
+        refresh_token=create_refresh_token(
+            user_id, expires_delta=refresh_token_expires
+        ),
+    )
 
 
 @router.post("/login/access-token")
 def login_access_token(
     session: SessionDep, form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
 ) -> Token:
-    """Authenticate a user and return a JWT access token.
+    """Authenticate a user and return a JWT access + refresh token pair.
 
     Uses OAuth2 password flow — credentials are submitted as form data.
-    The returned token should be included in subsequent requests as:
-        Authorization: Bearer <token>
+    The access token should be included in subsequent requests as:
+        Authorization: Bearer <access_token>
+    The refresh token is exchanged at POST /login/refresh-token when the access
+    token expires.
     """
     user = users_crud.authenticate(
         session=session, email=form_data.username, password=form_data.password
@@ -47,10 +64,28 @@ def login_access_token(
             status_code=http_status.HTTP_400_BAD_REQUEST,
             detail="Inactive user",
         )
-    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    return Token(
-        access_token=create_access_token(user.id, expires_delta=access_token_expires)
+    return _build_token(user.id)
+
+
+@router.post("/login/refresh-token")
+def refresh_access_token(session: SessionDep, body: RefreshTokenRequest) -> Token:
+    """Exchange a valid refresh token for a fresh access + refresh token pair.
+
+    The refresh token is rotated on every call (sliding window). Returns 401 if
+    the refresh token is missing, expired, tampered with, the wrong token type,
+    or the user no longer exists / is inactive.
+    """
+    invalid_token = HTTPException(
+        status_code=http_status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate refresh token",
     )
+    user_id = decode_refresh_token(body.refresh_token)
+    if user_id is None:
+        raise invalid_token
+    user = session.get(User, user_id)
+    if not user or not user.is_active:
+        raise invalid_token
+    return _build_token(user.id)
 
 
 @router.post("/password-recovery/{email}")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -93,11 +93,15 @@ class Settings(BaseSettings):
     # In production, set this to a stable secret via the environment.
     SECRET_KEY: str = secrets.token_urlsafe(32)
 
-    # TODO: Reduce this once refresh tokens are implemented. Long-lived access
-    # tokens are a security risk — a stolen token stays valid for 90 days.
-    # The proper fix is short-lived access tokens (e.g. 15 min) paired with a
-    # longer-lived refresh token that issues new access tokens.
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 90  # 90 days
+    # Short-lived access tokens limit the damage of a stolen token. Clients use
+    # a long-lived refresh token (below) to silently mint new access tokens via
+    # POST /login/refresh-token, so users are not forced to re-login.
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30  # 30 minutes
+
+    # Refresh tokens are long-lived and re-issued on every refresh (sliding
+    # window), so an actively-used client effectively never logs out; an idle
+    # client only re-authenticates after this window lapses.
+    REFRESH_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 90  # 90 days
 
     # How long password-reset links stay valid
     EMAIL_RESET_TOKEN_EXPIRE_HOURS: int = 48

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -48,8 +48,37 @@ def create_access_token(subject: str | Any, expires_delta: timedelta) -> str:
         future requests via the Authorization: Bearer header.
     """
     expire = datetime.now(timezone.utc) + expires_delta
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode = {"exp": expire, "sub": str(subject), "type": "access"}
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(subject: str | Any, expires_delta: timedelta) -> str:
+    """Create a signed, long-lived JWT refresh token for the given subject.
+
+    Refresh tokens are exchanged at POST /login/refresh-token for a fresh access
+    token. They carry a ``type: "refresh"`` claim so they cannot be used as an
+    access token on protected endpoints (see ``decode_refresh_token`` and
+    ``get_current_user``).
+    """
+    expire = datetime.now(timezone.utc) + expires_delta
+    to_encode = {"exp": expire, "sub": str(subject), "type": "refresh"}
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_refresh_token(token: str) -> str | None:
+    """Validate a refresh token and return its subject (the user ID).
+
+    Returns None if the token is missing, expired, tampered with, or is not a
+    refresh token (e.g. an access token submitted to the refresh endpoint).
+    """
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.exceptions.InvalidTokenError:
+        return None
+    if payload.get("type") != "refresh":
+        return None
+    sub = payload.get("sub")
+    return str(sub) if sub is not None else None
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -24,18 +24,27 @@ class Message(SQLModel):
     message: str
 
 
-# JSON payload containing access token
+# JSON payload containing the access token and its refresh token
 class Token(SQLModel):
     access_token: str
+    refresh_token: str
     token_type: str = Field(
         default="bearer", description="Type of the token, usually 'bearer'"
     )
+
+
+# Request body for exchanging a refresh token for a fresh access token
+class RefreshTokenRequest(SQLModel):
+    refresh_token: str
 
 
 # Contents of JWT token
 class TokenPayload(SQLModel):
     sub: str | None = Field(
         default=None, description="Subject of the token, usually the user ID"
+    )
+    type: str | None = Field(
+        default=None, description="Token type: 'access' or 'refresh'"
     )
 
 

--- a/backend/tests/api/test_login.py
+++ b/backend/tests/api/test_login.py
@@ -1,0 +1,80 @@
+"""Tests for the login + refresh-token auth flow."""
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+def _login(client: TestClient) -> dict[str, str]:
+    r = client.post(
+        f"{settings.API_V1_STR}/login/access-token",
+        data={
+            "username": settings.FIRST_SUPERUSER,
+            "password": settings.FIRST_SUPERUSER_PASSWORD,
+        },
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_login_returns_access_and_refresh_tokens(client: TestClient) -> None:
+    tokens = _login(client)
+    assert tokens["access_token"]
+    assert tokens["refresh_token"]
+    assert tokens["token_type"] == "bearer"
+
+
+def test_access_token_authenticates_protected_route(client: TestClient) -> None:
+    tokens = _login(client)
+    r = client.get(
+        f"{settings.API_V1_STR}/me",
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+    assert r.status_code == 200
+
+
+def test_refresh_returns_new_working_tokens(client: TestClient) -> None:
+    tokens = _login(client)
+    r = client.post(
+        f"{settings.API_V1_STR}/login/refresh-token",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert r.status_code == 200, r.text
+    new_tokens = r.json()
+    assert new_tokens["access_token"]
+    assert new_tokens["refresh_token"]
+
+    # The freshly minted access token authenticates a protected route.
+    me = client.get(
+        f"{settings.API_V1_STR}/me",
+        headers={"Authorization": f"Bearer {new_tokens['access_token']}"},
+    )
+    assert me.status_code == 200
+
+
+def test_access_token_rejected_at_refresh_endpoint(client: TestClient) -> None:
+    """An access token is not a refresh token and must be rejected (type claim)."""
+    tokens = _login(client)
+    r = client.post(
+        f"{settings.API_V1_STR}/login/refresh-token",
+        json={"refresh_token": tokens["access_token"]},
+    )
+    assert r.status_code == 401
+
+
+def test_refresh_token_rejected_as_bearer_credentials(client: TestClient) -> None:
+    """A refresh token must not be usable as an access token on protected routes."""
+    tokens = _login(client)
+    r = client.get(
+        f"{settings.API_V1_STR}/me",
+        headers={"Authorization": f"Bearer {tokens['refresh_token']}"},
+    )
+    assert r.status_code == 401
+
+
+def test_refresh_with_garbage_token_is_unauthorized(client: TestClient) -> None:
+    r = client.post(
+        f"{settings.API_V1_STR}/login/refresh-token",
+        json={"refresh_token": "not-a-real-token"},
+    )
+    assert r.status_code == 401

--- a/shared/client/sdk.gen.ts
+++ b/shared/client/sdk.gen.ts
@@ -17,6 +17,8 @@ import type {
   FriendsRemoveFriendResponse,
   LoginLoginAccessTokenData,
   LoginLoginAccessTokenResponse,
+  LoginRefreshAccessTokenData,
+  LoginRefreshAccessTokenResponse,
   LoginRecoverPasswordData,
   LoginRecoverPasswordResponse,
   LoginResetPasswordData,
@@ -276,11 +278,13 @@ export class FriendsService {
 export class LoginService {
   /**
    * Login Access Token
-   * Authenticate a user and return a JWT access token.
+   * Authenticate a user and return a JWT access + refresh token pair.
    *
    * Uses OAuth2 password flow — credentials are submitted as form data.
-   * The returned token should be included in subsequent requests as:
-   * Authorization: Bearer <token>
+   * The access token should be included in subsequent requests as:
+   * Authorization: Bearer <access_token>
+   * The refresh token is exchanged at POST /login/refresh-token when the access
+   * token expires.
    * @param data The data for the request.
    * @param data.formData
    * @returns Token Successful Response
@@ -294,6 +298,32 @@ export class LoginService {
       url: "/api/v1/login/access-token",
       formData: data.formData,
       mediaType: "application/x-www-form-urlencoded",
+      errors: {
+        422: "Validation Error",
+      },
+    })
+  }
+
+  /**
+   * Refresh Access Token
+   * Exchange a valid refresh token for a fresh access + refresh token pair.
+   *
+   * The refresh token is rotated on every call (sliding window). Returns 401 if
+   * the refresh token is missing, expired, tampered with, the wrong token type,
+   * or the user no longer exists / is inactive.
+   * @param data The data for the request.
+   * @param data.requestBody
+   * @returns Token Successful Response
+   * @throws ApiError
+   */
+  public static refreshAccessToken(
+    data: LoginRefreshAccessTokenData,
+  ): CancelablePromise<LoginRefreshAccessTokenResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/login/refresh-token",
+      body: data.requestBody,
+      mediaType: "application/json",
       errors: {
         422: "Validation Error",
       },

--- a/shared/client/types.gen.ts
+++ b/shared/client/types.gen.ts
@@ -232,6 +232,10 @@ export type PushTokenRegister = {
   platform?: "ios" | "android" | "web" | null
 }
 
+export type RefreshTokenRequest = {
+  refresh_token: string
+}
+
 export type SavedPresetCreate = {
   name: string
   scope: FilterPresetScope
@@ -365,6 +369,7 @@ export type TmdbCacheOverrideResponse = {
 
 export type Token = {
   access_token: string
+  refresh_token: string
   /**
    * Type of the token, usually 'bearer'
    */
@@ -484,6 +489,12 @@ export type LoginLoginAccessTokenData = {
 }
 
 export type LoginLoginAccessTokenResponse = Token
+
+export type LoginRefreshAccessTokenData = {
+  requestBody: RefreshTokenRequest
+}
+
+export type LoginRefreshAccessTokenResponse = Token
 
 export type LoginRecoverPasswordData = {
   email: string


### PR DESCRIPTION
## Why

Access tokens lasted **90 days** with no refresh mechanism, so once a token expired the user was forced to log in again — and before #270 the app soft-locked on the resulting 401. This was the root cause of the production 401s.

## What

Short-lived access tokens + a long-lived **stateless** refresh token (no DB table, matching the current non-revocable model).

- **Access token**: 30 min, carries `type: "access"`.
- **Refresh token**: 90 days, carries `type: "refresh"`, re-issued on every refresh (sliding window) — an actively-used client never gets logged out; an idle one re-auths only after 90 days.
- `POST /login/access-token` now returns `{ access_token, refresh_token }`.
- New `POST /login/refresh-token` exchanges a valid refresh token for a fresh pair; returns 401 on invalid/expired/wrong-type token or unknown/inactive user.
- `get_current_user` rejects tokens with `type == "refresh"`. **Backward compatible:** existing already-issued access tokens predate the `type` claim (type=None) and remain valid until they expire.

## Tests
New `tests/api/test_login.py`: login returns both tokens; refresh returns new working tokens; access token rejected at `/login/refresh-token`; refresh token rejected as bearer credentials at `/me/`; garbage refresh → 401. Full API suite (115 tests) green; `mypy` + `ruff` clean.

## Client
Regenerated `shared/client` — `Token.refresh_token`, `RefreshTokenRequest`, `LoginService.refreshAccessToken`.

## Follow-up (separate, on ui-overhaul)
Mobile consumes this: store the refresh token and add a global axios interceptor that silently refreshes on 401 before falling back to the #270 logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)