### PR TITLE
hotfix: add restart policy to scheduler service (prod scraper down)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB?Variable not set}
 
   scheduler:
+    restart: always
     build:
       context: ./backend
     command: ["python", "-m", "app.scheduler"]


### PR DESCRIPTION
## Emergency hotfix — production only

The `scheduler` container on production (mikino.nl) was **OOM-killed on 2026-07-12 and never restarted**, silently stopping all scrapes and scrape/recap emails for ~5 days. It was the only long-running service in `docker-compose.yml` without a `restart:` policy, so Docker never revived it after the kill.

This adds `restart: always` to the scheduler service so Docker automatically brings it back.

### Scope
Single-line change to `docker-compose.yml` only. Cherry-picked from `dev` (`43c8bb4`) so it does **not** drag any other unmerged dev work into production.

### Related mitigation (already applied on the host, not in this PR)
- Restarted the dead prod scheduler container manually (emails resumed).
- Added a 2 GB swapfile on `mi-ki` (no swap previously; host is memory-constrained) to reduce OOM recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)