### PR TITLE
Fix homepage branding/description for Google OAuth consent verification

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MIKINO</title>
+    <title>MiKiNO</title>
     <link rel="icon" type="image/x-icon" href="/assets/images/favicon.png" />
+    <meta
+      name="description"
+      content="MiKiNO helps you discover what's playing at cinemas in your city, keep track of what you want to see, and coordinate showtimes with friends."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mikino.nl/" />
-    <meta property="og:site_name" content="MIKINO" />
-    <meta property="og:title" content="MIKINO" />
+    <meta property="og:site_name" content="MiKiNO" />
+    <meta property="og:title" content="MiKiNO" />
     <meta property="og:description" content="Discover what is playing in your city." />
     <meta property="og:image" content="https://mikino.nl/assets/images/mikino-logo.png" />
     <meta property="og:image:secure_url" content="https://mikino.nl/assets/images/mikino-logo.png" />
@@ -17,12 +21,20 @@
     <meta property="og:image:width" content="1024" />
     <meta property="og:image:height" content="1024" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="MIKINO" />
+    <meta name="twitter:title" content="MiKiNO" />
     <meta name="twitter:description" content="Discover what is playing in your city." />
     <meta name="twitter:image" content="https://mikino.nl/assets/images/mikino-logo.png" />
   </head>
   <body>
     <div id="root"></div>
+    <noscript>
+      <h1>MiKiNO</h1>
+      <p>
+        MiKiNO helps you discover what's playing at cinemas in your city, keep
+        track of movies you want to see, and coordinate showtimes with
+        friends.
+      </p>
+    </noscript>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Google's OAuth consent screen review flagged the site: the app name casing on the homepage ("MIKINO") didn't match the OAuth consent screen's app name ("MiKiNO"), and the SPA had no crawlable static text explaining what the app does.
- Fixed casing to "MiKiNO" everywhere (title, og/twitter meta tags), added a proper `<meta name="description">`, and added a `<noscript>` block with real descriptive copy so it's visible even without JS execution.

## Test plan
- [ ] Visit https://mikino.nl after deploy and confirm the tab title reads "MiKiNO"
- [ ] View page source and confirm the `<noscript>` description block is present
- [ ] Re-run the Google OAuth consent screen verification check