### PR TITLE
Show app name and description on login/signup screens

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -83,8 +83,15 @@ function Login() {
           height="auto"
           maxW="2xs"
           alignSelf="center"
-          mb={4}
+          mb={2}
         />
+        <Text fontSize="2xl" fontWeight="bold" textAlign="center">
+          MiKiNO
+        </Text>
+        <Text color="gray.500" textAlign="center" mb={2}>
+          Discover what's playing at cinemas in your city, and coordinate
+          showtimes with friends.
+        </Text>
         <Field invalid={!!errors.username} errorText={errors.username?.message}>
           <InputGroup w="100%" startElement={<FiMail />}>
             <Input

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -89,8 +89,15 @@ function SignUp() {
             height="auto"
             maxW="2xs"
             alignSelf="center"
-            mb={4}
+            mb={2}
           />
+          <Text fontSize="2xl" fontWeight="bold" textAlign="center">
+            MiKiNO
+          </Text>
+          <Text color="gray.500" textAlign="center" mb={2}>
+            Discover what's playing at cinemas in your city, and coordinate
+            showtimes with friends.
+          </Text>
           <Field
             invalid={!!errors.display_name}
             errorText={errors.display_name?.message}


### PR DESCRIPTION
## Summary
- Google's OAuth consent verification still failed after the previous meta-tag fix (PR #291) — it renders the page like a real browser rather than reading raw HTML, and the homepage redirects any anonymous visitor straight to the login form.
- The login/signup screens only had a logo image (not crawlable text) and form fields — no visible text anywhere saying "MiKiNO" or explaining what the app does.
- Added a visible "MiKiNO" heading and a one-line description under the logo on both `/login` and `/signup`.

## Test plan
- [ ] Visit https://mikino.nl (or /login directly) after deploy and confirm "MiKiNO" and the description text render visibly above the form
- [ ] Re-run the Google OAuth consent screen verification check