### PR TITLE
Add a public, non-gated homepage for Google OAuth verification

### DIFF
--- a/frontend/public/about.html
+++ b/frontend/public/about.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MiKiNO</title>
+    <meta
+      name="description"
+      content="MiKiNO helps you discover what's playing at cinemas in your city, keep track of what you want to see, and coordinate showtimes with friends."
+    />
+    <style>
+      :root {
+        --bg: #f8fafc;
+        --text: #0f172a;
+        --muted: #475569;
+        --card: #ffffff;
+        --border: #e2e8f0;
+        --accent: #0b6bcb;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.6;
+      }
+      .wrap {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 32px;
+        text-align: center;
+      }
+      .logo {
+        width: 96px;
+        height: 96px;
+        border-radius: 20px;
+        margin-bottom: 16px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 32px;
+      }
+      p {
+        color: var(--muted);
+        text-align: left;
+      }
+      .lede {
+        text-align: center;
+        font-size: 18px;
+      }
+      .cta {
+        display: inline-block;
+        margin: 8px 8px 0;
+        padding: 12px 24px;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .cta.secondary {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+      }
+      .links {
+        margin-top: 28px;
+        font-size: 14px;
+      }
+      a {
+        color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <article class="card">
+        <img
+          class="logo"
+          src="/assets/images/mikino-logo.png"
+          alt="MiKiNO logo"
+        />
+        <h1>MiKiNO</h1>
+        <p class="lede">
+          Discover what's playing at cinemas in your city, keep track of the
+          movies you want to see, and coordinate showtimes with friends.
+        </p>
+        <p>
+          MiKiNO aggregates showtimes from cinemas near you so you can browse,
+          filter, and find something to watch. Save movies to your watchlist,
+          see when friends are going to the same showing, and get notified
+          about screenings you care about.
+        </p>
+        <p>
+          You can create a MiKiNO account with your email address, or sign in
+          with your Google or Apple account for faster, one-tap access — we
+          only use this to identify your account and never post or share
+          anything on your behalf.
+        </p>
+        <a class="cta" href="/login">Open MiKiNO</a>
+        <a class="cta secondary" href="/beta">Get the app</a>
+        <p class="links">
+          <a href="/privacy-policy.html">Privacy Policy</a>
+        </p>
+      </article>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Google's OAuth verification kept failing "home page doesn't explain purpose" / "app name doesn't match" even after adding visible text to the login screen (PR #292).
- Root cause, per Google's actual policy docs: **a login page cannot be used as the OAuth app's home page at all** — it must be "visible to users without requiring them to log in." The site's `/` always redirects anonymous visitors straight to `/login`, so nothing on the domain satisfied that requirement regardless of what text was on the login form.
- Added `frontend/public/about.html`: a static page (no auth, no JS/build dependency, matching the style of the existing `privacy-policy.html`) that names the app, explains what it does, links to the privacy policy, and links into the app (`/login`) and app store install instructions (`/beta`).

## Follow-up needed (not part of this PR)
Once merged, the OAuth consent screen's "Application home page" field needs to be updated in Google Cloud Console to `https://mikino.nl/about.html` instead of the bare domain root, then re-run verification.

## Test plan
- [ ] Visit https://mikino.nl/about.html after deploy (while logged out) and confirm it renders without any redirect to /login
- [ ] Update the OAuth consent screen homepage URL and re-run verification