### PR TITLE
Guard movie.description from clobber, add description backfill script

### DIFF
--- a/backend/app/crud/movie.py
+++ b/backend/app/crud/movie.py
@@ -227,6 +227,10 @@ def upsert_movie(*, session: Session, movie_create: MovieCreate) -> Movie:
         movie_data.pop("cast", None)
     if movie_data.get("directors") is None and db_obj.directors is not None:
         movie_data.pop("directors", None)
+    # A transient/skipped TMDB fetch must not wipe previously-enriched
+    # description back to NULL.
+    if movie_data.get("description") is None and db_obj.description is not None:
+        movie_data.pop("description", None)
     db_obj.sqlmodel_update(movie_data)
     return db_obj
 

--- a/backend/scripts/backfill-movie-description.py
+++ b/backend/scripts/backfill-movie-description.py
@@ -1,0 +1,55 @@
+"""One-off backfill: populate Movie.description from TMDB.
+
+The description column was added after movies already existed (migration
+e2f4a6c8b0d2), so every pre-existing row starts NULL. This re-fetches TMDB
+details for movies missing a description and writes the result. Safe to
+rerun; only touches rows where description IS NULL. Run once after
+deploying the migration:
+
+    python scripts/backfill-movie-description.py
+"""
+
+import time
+
+from sqlmodel import col, select
+
+from app.api.deps import get_db_context
+from app.models.movie import Movie
+from app.scraping import tmdb_lookup as tmdb_core
+
+REQUEST_DELAY_SECONDS = 0.05
+
+
+def backfill_description() -> None:
+    with get_db_context() as session:
+        movie_ids = list(
+            session.exec(
+                select(Movie.id).where(col(Movie.description).is_(None))
+            ).all()
+        )
+
+    print(f"Backfilling description for {len(movie_ids)} movies")
+    updated = 0
+    skipped = 0
+    for movie_id in movie_ids:
+        details = tmdb_core.fetch_tmdb_movie_details_sync(movie_id)
+        if details is None or details.description is None:
+            skipped += 1
+            time.sleep(REQUEST_DELAY_SECONDS)
+            continue
+
+        with get_db_context() as session:
+            movie = session.get(Movie, movie_id)
+            if movie is not None and movie.description is None:
+                movie.description = details.description
+                session.add(movie)
+                session.commit()
+                updated += 1
+
+        time.sleep(REQUEST_DELAY_SECONDS)
+
+    print(f"Done. Updated {updated}, skipped {skipped} (no TMDB data available)")
+
+
+if __name__ == "__main__":
+    backfill_description()

--- a/backend/tests/crud/test_movie_crud.py
+++ b/backend/tests/crud/test_movie_crud.py
@@ -217,6 +217,30 @@ def test_upsert_movie_preserves_existing_language_data_when_payload_language_is_
     assert updated_movie.original_language == "en"
 
 
+def test_upsert_movie_preserves_existing_description_when_payload_description_is_missing(
+    *,
+    db_transaction: Session,
+    movie_factory: Callable[..., Movie],
+):
+    """A transient/skipped TMDB fetch must not wipe previously-enriched description."""
+    existing_movie = movie_factory(description="A gripping tale of two cities.")
+    movie_create = MovieCreate(
+        id=existing_movie.id,
+        title=existing_movie.title,
+        poster_link=existing_movie.poster_link,
+        letterboxd_slug=existing_movie.letterboxd_slug,
+        description=None,
+    )
+
+    updated_movie = movie_crud.upsert_movie(
+        session=db_transaction,
+        movie_create=movie_create,
+    )
+
+    assert updated_movie.id == existing_movie.id
+    assert updated_movie.description == "A gripping tale of two cities."
+
+
 def test_upsert_movie_updates_language_data_when_payload_has_real_values(
     *,
     db_transaction: Session,


### PR DESCRIPTION
Same bug class as the earlier cast/directors clobber: every scraper sets description=None when TMDB details aren't fetched, and upsert_movie had no guard, so a transient TMDB failure would wipe a backfilled description back to NULL on the next scrape cycle.